### PR TITLE
Connection strings rule

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/.idea/gradle.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/.idea/gradle.xml
@@ -14,6 +14,7 @@
             <option value="$PROJECT_DIR$/azure-intellij-plugin-appservice" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-appservice-java" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-arm" />
+            <option value="$PROJECT_DIR$/azure-intellij-plugin-azure-sdk" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-bicep" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-cognitiveservices" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-containerapps" />
@@ -28,11 +29,13 @@
             <option value="$PROJECT_DIR$/azure-intellij-plugin-hdinsight" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-hdinsight-base" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-hdinsight-lib" />
+            <option value="$PROJECT_DIR$/azure-intellij-plugin-integration-services" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-keyvault" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-lib" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-lib-java" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-monitor" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-redis" />
+            <option value="$PROJECT_DIR$/azure-intellij-plugin-samples" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-service-explorer" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-servicebus" />
             <option value="$PROJECT_DIR$/azure-intellij-plugin-sparkoncosmos" />

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ConnectionStringCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ConnectionStringCheck.java
@@ -1,0 +1,29 @@
+package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
+
+import com.intellij.codeInspection.*;
+import com.intellij.psi.*;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This class extends the LocalInspectionTool and checks for the usage of connection strings in the code.
+ * Connection strings that start with "DefaultEndpointsProtocol=http;AccountName=" are flagged as problems.
+ * This is because the use of such connection strings is not recommended.
+ */
+public class ConnectionStringCheck extends LocalInspectionTool {
+    @NotNull
+    @Override
+    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder holder, boolean isOnTheFly) {
+        return new JavaElementVisitor() {
+            @Override
+            public void visitLiteralExpression(PsiLiteralExpression expression) {
+                super.visitLiteralExpression(expression);
+
+                String value = expression.getValue() instanceof String ? (String) expression.getValue() : null;
+
+                if (value != null && value.startsWith("DefaultEndpointsProtocol=http;AccountName=")) {
+                    holder.registerProblem(expression, "Use of connection strings is not recommended");
+                }
+            }
+        };
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
@@ -23,5 +23,19 @@
                 implementationClass="com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.MavenProjectInspection">
             <class>com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.MavenProjectInspection</class>
         </localInspection>
+
+        <localInspection
+                language="JAVA"
+                shortName="ConnectionStringCheck"
+                displayName="Connection String Check"
+                groupName="Maven"
+                enabledByDefault="true"
+                level="WARNING"
+                implementationClass="com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.ConnectionStringCheck">
+
+            <class>
+                com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.ClosingCloseableClientsCheck
+            </class>
+        </localInspection>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
checks for the usage of connection strings in the code.
Connection strings that start with "DefaultEndpointsProtocol=http;AccountName=" are flagged as problems.

Any other comments?
-------------------
TODOS once I merge first PR and pull from it
- add recommendation to README
- write tests

Has this been tested?
---------------------------
- [ ] Tested
