### PR TITLE
Authenticating non azure openai

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
@@ -162,43 +162,46 @@ integration, telemetry connectivity, and Azure Toolkit integration.
 
 9. #### Use these encouraged clients instead of their corresponding discouraged clients
 
-    ##### a. Use **`ServiceBusProcessorClient`** instead of **`ServiceBusReceiverAsyncClient`**
+   ##### a. Use **`ServiceBusProcessorClient`** instead of **`ServiceBusReceiverAsyncClient`**
 
-    ##### b. Use **`EventProcessorClient`** instead of **`EventHubConsumerAsyncClient`**
-    
-    ##### Anti-pattern:
-    
-    - Both `ServiceBusReceiverAsyncClient` and `EventHubConsumerAsyncClient` are low-level APIs. They provide fine-grained
+   ##### b. Use **`EventProcessorClient`** instead of **`EventHubConsumerAsyncClient`**
+
+   ##### Anti-pattern:
+
+    - Both `ServiceBusReceiverAsyncClient` and `EventHubConsumerAsyncClient` are low-level APIs. They provide
+      fine-grained
       control over message/event handling but require a high level of proficiency in Reactive programming.
-    - Due to their complexity and the need for a deep understanding of Reactive programming, there is a higher risk of these
+    - Due to their complexity and the need for a deep understanding of Reactive programming, there is a higher risk of
+      these
       clients being used incorrectly or inefficiently, especially by developers who are not familiar with Reactive
       paradigms.
 
-    ##### Issue:
+   ##### Issue:
 
-    ##### a. **ServiceBusReceiverAsyncClient**
+   ##### a. **ServiceBusReceiverAsyncClient**
 
-   - **Anti-pattern**: The `ServiceBusReceiverAsyncClient` is considered an anti-pattern because it demands detailed
-   handling of messages, which can be overly complex and unnecessary for most common use cases.
-   - **Severity: WARNING**
-   - **Recommendation**: Instead of using `ServiceBusReceiverAsyncClient`, it is recommended to
-     use `ServiceBusProcessorClient`. The `ServiceBusProcessorClient` is a higher-level abstraction that simplifies
-     message consumption, making it a more suitable option for most developers and scenarios.
-   - Please refer to
-     the [Azure Service Bus client for Java](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/servicebus/azure-messaging-servicebus/README.md#when-to-use-servicebusprocessorclient)
-     for more information.
+    - **Anti-pattern**: The `ServiceBusReceiverAsyncClient` is considered an anti-pattern because it demands detailed
+      handling of messages, which can be overly complex and unnecessary for most common use cases.
+    - **Severity: WARNING**
+    - **Recommendation**: Instead of using `ServiceBusReceiverAsyncClient`, it is recommended to
+      use `ServiceBusProcessorClient`. The `ServiceBusProcessorClient` is a higher-level abstraction that simplifies
+      message consumption, making it a more suitable option for most developers and scenarios.
+    - Please refer to
+      the [Azure Service Bus client for Java](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/servicebus/azure-messaging-servicebus/README.md#when-to-use-servicebusprocessorclient)
+      for more information.
 
-    ##### b. **EventHubConsumerAsyncClient**
-    
-    - **Anti-pattern**: The `EventHubConsumerAsyncClient` is considered an anti-pattern due to its low-level nature and the
-    complexity involved in event handling.
+   ##### b. **EventHubConsumerAsyncClient**
+
+    - **Anti-pattern**: The `EventHubConsumerAsyncClient` is considered an anti-pattern due to its low-level nature and
+      the
+      complexity involved in event handling.
     - **Severity: WARNING**
     - **Recommendation**: Instead of using `EventHubConsumerAsyncClient`, it is advised to use `EventProcessorClient`.
-    The `EventProcessorClient` provides a higher-level abstraction that simplifies event processing, making it the
-    preferred choice for most developers.
+      The `EventProcessorClient` provides a higher-level abstraction that simplifies event processing, making it the
+      preferred choice for most developers.
     - Please refer to
-    the [EventProcessorClient Class](https://learn.microsoft.com/en-us/java/api/com.azure.messaging.eventhubs.eventprocessorclient?view=azure-java-stable)
-    for more information.
+      the [EventProcessorClient Class](https://learn.microsoft.com/en-us/java/api/com.azure.messaging.eventhubs.eventprocessorclient?view=azure-java-stable)
+      for more information.
 
 10. #### Using Batch Operations Instead of Single Operations in a Loop
 
@@ -212,3 +215,16 @@ integration, telemetry connectivity, and Azure Toolkit integration.
 - **Severity: WARNING**
 - **Recommendation**: Use Batch Operations: If the SDK provides a batch operation API, use it to perform multiple
   actions in a single request.
+
+11. #### Authenticating a Non-Azure OpenAI Client with KeyCredential
+
+- **Anti-pattern**: Assigning the endpoint value when creating a Non-Azure OpenAI client using the KeyCredential in
+  .credential(KeyCredential).
+- **Issue**: KeyCredential is the only required parameter in `.credential(KeyCredential)` for authenticating requests to
+  non-Azure OpenAI APIs.
+- **Severity: WARNING**
+- **Recommendation**: Omit Endpoint: Do not specify the endpoint parameter unless you are working with Azure-specific
+  OpenAI services that require it.
+  Please refer to
+  the [KeyCredential Class documentation](https://learn.microsoft.com/java/api/com.azure.core.credential.keycredential?view=azure-java-stable)
+  for more information.

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
@@ -255,8 +255,8 @@ integration, telemetry connectivity, and Azure Toolkit integration.
 - **Issue**: KeyCredential is the only required parameter in `.credential(KeyCredential)` for authenticating requests to
   non-Azure OpenAI APIs.
 - **Severity: WARNING**
-- **Recommendation**: Omit Endpoint: Do not specify the endpoint parameter unless you are working with Azure-specific
-  OpenAI services that require it.
+- **Recommendation**: Omit Endpoint: Only specify the endpoint parameter if you are working with Azure OpenAI services
+  that require it. Otherwise, it is not necessary to authenticate non-Azure Open-AI clients.
   Please refer to
   the [KeyCredential Class documentation](https://learn.microsoft.com/java/api/com.azure.core.credential.keycredential?view=azure-java-stable)
   for more information.

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheck.java
@@ -5,83 +5,122 @@ import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.JavaElementVisitor;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiExpression;
-import com.intellij.psi.PsiExpressionList;
-import com.intellij.psi.PsiLocalVariable;
 import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.PsiNewExpression;
 import com.intellij.psi.PsiReferenceExpression;
 import com.intellij.psi.PsiType;
-import com.intellij.psi.PsiTypeElement;
 import com.intellij.psi.PsiVariable;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
-
+/**
+ * This class is a LocalInspectionTool that checks if the endpoint method is used with KeyCredential for non-Azure OpenAI clients.
+ * If the endpoint method is used with KeyCredential for non-Azure OpenAI clients, a warning is registered.
+ */
 public class EndpointOnNonAzureOpenAIAuthCheck extends LocalInspectionTool {
 
+    /**
+     * This method builds the visitor for the inspection tool.
+     *
+     * @param holder     The ProblemsHolder object that holds the problems found by the inspection tool.
+     * @param isOnTheFly A boolean that indicates if the inspection tool is running on the fly. - this is not used in this implementation but is required by the method signature.
+     * @return The JavaElementVisitor object that will be used to visit the elements in the code.
+     */
     @NotNull
     @Override
     public JavaElementVisitor buildVisitor(@NotNull ProblemsHolder holder, boolean isOnTheFly) {
-        return new EndpointOnNonAzureOpenAIAuthVisitor(holder, isOnTheFly);
+        return new EndpointOnNonAzureOpenAIAuthVisitor(holder);
     }
 
-
+    /**
+     * This class is a JavaElementVisitor that visits the elements in the code and checks if the endpoint method is used with KeyCredential for non-Azure OpenAI clients.
+     */
     static class EndpointOnNonAzureOpenAIAuthVisitor extends JavaElementVisitor {
 
         private final ProblemsHolder holder;
+        private static final RuleConfig RULE_CONFIG;
 
-        EndpointOnNonAzureOpenAIAuthVisitor(ProblemsHolder holder, boolean isOnTheFly) {
+        // The boolean that indicates if the rule should be skipped
+        private static final boolean SKIP_WHOLE_RULE;
+
+        /**
+         * Constructor for the visitor.
+         *
+         * @param holder The ProblemsHolder object that holds the problems found by the inspection tool.
+         */
+        EndpointOnNonAzureOpenAIAuthVisitor(ProblemsHolder holder) {
             this.holder = holder;
         }
 
+        // Static initializer block to load the configurations once
+        static {
+            String ruleName = "EndpointOnNonAzureOpenAIAuthCheck";
+            RuleConfigLoader centralRuleConfigLoader = RuleConfigLoader.getInstance();
 
+            // Get the RuleConfig object for the rule
+            RULE_CONFIG = centralRuleConfigLoader.getRuleConfig(ruleName);
+            SKIP_WHOLE_RULE = RULE_CONFIG.skipRuleCheck() || RULE_CONFIG.getMethodsToCheck().isEmpty();
+        }
+
+        /**
+         * This method visits the method call expressions in the code.
+         * If the method call expression is the endpoint method, the method call chain is checked to see if it is a non-Azure OpenAI client.
+         * If the method call chain uses the credential method with KeyCredential for non-Azure OpenAI clients, a warning is registered.
+         *
+         * @param expression The method call expression to visit.
+         */
         @Override
         public void visitMethodCallExpression(@NotNull PsiMethodCallExpression expression) {
             super.visitMethodCallExpression(expression);
 
+            if (SKIP_WHOLE_RULE) {
+                return;
+            }
+
             PsiReferenceExpression methodExpression = expression.getMethodExpression();
             String methodName = methodExpression.getReferenceName();
 
-            System.out.println("methodName: " + methodName);
+            if (!(RULE_CONFIG.getMethodsToCheck().contains(methodName))) {
+                return;
+            }
 
+            // Check if the method is the endpoint method
             if ("endpoint".equals(methodName)) {
+
+                // Using KeyCredential indicates authentication of a non-Azure OpenAI client
+                // If the endpoint method is used with KeyCredential for non-Azure OpenAI clients, a warning is registered
                 if (isUsingKeyCredential(expression)) {
                     holder.registerProblem(expression, "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients");
                 }
             }
-
-
         }
 
+        /**
+         * This method checks if the method call chain uses the credential method with KeyCredential.
+         * If this is the case, the method call chain is checked to see if it is a non-Azure OpenAI client.
+         *
+         * @param expression The method call expression to check.
+         * @return True if the method call chain uses the credential method with KeyCredential, false otherwise.
+         */
         private static boolean isUsingKeyCredential(PsiMethodCallExpression expression) {
 
             // Iterating up the chain of method calls
             PsiExpression qualifier = expression.getMethodExpression().getQualifierExpression();
 
-            System.out.println("qualifier: " + qualifier);
-
-            // Check if the method call chain has the method to check -- need to traverse up and down
+            // Check if the method call chain has 'credential' method
             while (qualifier instanceof PsiMethodCallExpression) {
 
-                // Get the method expression
                 PsiReferenceExpression methodExpression = ((PsiMethodCallExpression) qualifier).getMethodExpression();
-                System.out.println("methodExpression: " + methodExpression);
-
                 PsiMethodCallExpression methodCall = (PsiMethodCallExpression) qualifier;
-                System.out.println("methodCall: " + methodCall);
-
-                // Get the method name
                 String methodName = methodExpression.getReferenceName();
-                System.out.println("methodName: " + methodName);
+
+                if (!(RULE_CONFIG.getMethodsToCheck().contains(methodName))) {
+                    return false;
+                }
 
                 if ("credential".equals(methodName)) {
 
-                    System.out.println("credential method found");
-                    PsiExpressionList argumentList = methodCall.getArgumentList();
-                    System.out.println("argumentList: " + argumentList);
-                    System.out.println("methodCall.getArgumentList(): " + methodCall.getArgumentList());
-                    System.out.println("methodCall: " + methodCall);
+                    // Check if the credential method is used with KeyCredential
                     PsiExpression[] arguments = methodCall.getArgumentList().getExpressions();
-                    System.out.println("arguments: " + arguments);
                     if (arguments.length == 1 && isKeyCredential(arguments[0])) {
                         return isNonAzureOpenAIClient(methodCall);
                     }
@@ -94,26 +133,42 @@ public class EndpointOnNonAzureOpenAIAuthCheck extends LocalInspectionTool {
             return false;
         }
 
+        /**
+         * This method checks if the expression is a KeyCredential.
+         *
+         * @param expression The expression to check.
+         * @return True if the expression is a KeyCredential, false otherwise.
+         */
         private static boolean isKeyCredential(PsiExpression expression) {
 
-            System.out.println("expression.getType().getCanonicalText()): " + expression.getType().getCanonicalText());
-            System.out.println("expression.getType()); " + expression.getType());
+            if (expression instanceof PsiNewExpression) {
 
-            return expression.getType()!= null && expression.getType().getCanonicalText().equals("com.azure.core.credential.KeyCredential");
+                // Cast the element to a new expression
+                PsiNewExpression newExpression = (PsiNewExpression) expression;
+
+                // Get the class reference name from the new expression
+                String classReference = newExpression.getClassReference().getReferenceName();
+                if (classReference != null) {
+                    return RULE_CONFIG.getServicesToCheck().contains(classReference);
+                }
+            }
+            return false;
         }
 
+        /**
+         * This method checks if the method call chain is on a non-Azure OpenAI client.
+         *
+         * @param expression The method call expression to check.
+         * @return True if the client is a non-Azure OpenAI client, false otherwise.
+         */
         private static boolean isNonAzureOpenAIClient(PsiMethodCallExpression expression) {
             PsiElement parent = expression.getParent();
-            System.out.println("parent: " + parent);
 
             while (parent != null) {
-                System.out.println("parent: " + parent);
                 if (parent instanceof PsiVariable) {
 
                     PsiType type = ((PsiVariable) parent).getType();
-                    System.out.println("type: " + type);
-                    System.out.println("type.getCanonicalText(): " + type.getCanonicalText());
-                    if(type != null){
+                    if (type != null) {
                         return type.getCanonicalText().startsWith("com.azure.ai.openai");
                     }
                 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheck.java
@@ -89,7 +89,7 @@ public class EndpointOnNonAzureOpenAIAuthCheck extends LocalInspectionTool {
                 // Using KeyCredential indicates authentication of a non-Azure OpenAI client
                 // If the endpoint method is used with KeyCredential for non-Azure OpenAI clients, a warning is registered
                 if (isUsingKeyCredential(expression)) {
-                    holder.registerProblem(expression, "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients");
+                    holder.registerProblem(expression, RULE_CONFIG.getAntiPatternMessageMap().get("antiPatternMessage"));
                 }
             }
         }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheck.java
@@ -1,0 +1,125 @@
+package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
+
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiExpression;
+import com.intellij.psi.PsiExpressionList;
+import com.intellij.psi.PsiLocalVariable;
+import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.PsiReferenceExpression;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.PsiTypeElement;
+import com.intellij.psi.PsiVariable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+public class EndpointOnNonAzureOpenAIAuthCheck extends LocalInspectionTool {
+
+    @NotNull
+    @Override
+    public JavaElementVisitor buildVisitor(@NotNull ProblemsHolder holder, boolean isOnTheFly) {
+        return new EndpointOnNonAzureOpenAIAuthVisitor(holder, isOnTheFly);
+    }
+
+
+    static class EndpointOnNonAzureOpenAIAuthVisitor extends JavaElementVisitor {
+
+        private final ProblemsHolder holder;
+
+        EndpointOnNonAzureOpenAIAuthVisitor(ProblemsHolder holder, boolean isOnTheFly) {
+            this.holder = holder;
+        }
+
+
+        @Override
+        public void visitMethodCallExpression(@NotNull PsiMethodCallExpression expression) {
+            super.visitMethodCallExpression(expression);
+
+            PsiReferenceExpression methodExpression = expression.getMethodExpression();
+            String methodName = methodExpression.getReferenceName();
+
+            System.out.println("methodName: " + methodName);
+
+            if ("endpoint".equals(methodName)) {
+                if (isUsingKeyCredential(expression)) {
+                    holder.registerProblem(expression, "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients");
+                }
+            }
+
+
+        }
+
+        private static boolean isUsingKeyCredential(PsiMethodCallExpression expression) {
+
+            // Iterating up the chain of method calls
+            PsiExpression qualifier = expression.getMethodExpression().getQualifierExpression();
+
+            System.out.println("qualifier: " + qualifier);
+
+            // Check if the method call chain has the method to check -- need to traverse up and down
+            while (qualifier instanceof PsiMethodCallExpression) {
+
+                // Get the method expression
+                PsiReferenceExpression methodExpression = ((PsiMethodCallExpression) qualifier).getMethodExpression();
+                System.out.println("methodExpression: " + methodExpression);
+
+                PsiMethodCallExpression methodCall = (PsiMethodCallExpression) qualifier;
+                System.out.println("methodCall: " + methodCall);
+
+                // Get the method name
+                String methodName = methodExpression.getReferenceName();
+                System.out.println("methodName: " + methodName);
+
+                if ("credential".equals(methodName)) {
+
+                    System.out.println("credential method found");
+                    PsiExpressionList argumentList = methodCall.getArgumentList();
+                    System.out.println("argumentList: " + argumentList);
+                    System.out.println("methodCall.getArgumentList(): " + methodCall.getArgumentList());
+                    System.out.println("methodCall: " + methodCall);
+                    PsiExpression[] arguments = methodCall.getArgumentList().getExpressions();
+                    System.out.println("arguments: " + arguments);
+                    if (arguments.length == 1 && isKeyCredential(arguments[0])) {
+                        return isNonAzureOpenAIClient(methodCall);
+                    }
+                    return false;
+                }
+
+                // Iterating up the chain of method calls
+                qualifier = methodCall.getMethodExpression().getQualifierExpression();
+            }
+            return false;
+        }
+
+        private static boolean isKeyCredential(PsiExpression expression) {
+
+            System.out.println("expression.getType().getCanonicalText()): " + expression.getType().getCanonicalText());
+            System.out.println("expression.getType()); " + expression.getType());
+
+            return expression.getType()!= null && expression.getType().getCanonicalText().equals("com.azure.core.credential.KeyCredential");
+        }
+
+        private static boolean isNonAzureOpenAIClient(PsiMethodCallExpression expression) {
+            PsiElement parent = expression.getParent();
+            System.out.println("parent: " + parent);
+
+            while (parent != null) {
+                System.out.println("parent: " + parent);
+                if (parent instanceof PsiVariable) {
+
+                    PsiType type = ((PsiVariable) parent).getType();
+                    System.out.println("type: " + type);
+                    System.out.println("type.getCanonicalText(): " + type.getCanonicalText());
+                    if(type != null){
+                        return type.getCanonicalText().startsWith("com.azure.ai.openai");
+                    }
+                }
+                parent = parent.getParent();
+            }
+            return false;
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
@@ -168,5 +168,19 @@
                 com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.DetectDiscouragedClientCheck
             </class>
         </localInspection>
+
+        <localInspection
+                language="JAVA"
+                shortName="EndpointOnNonAzureOpenAIAuthCheck"
+                displayName="Endpoint On Non-Azure OpenAI Auth Check"
+                groupName="Azure SDK"
+                enabledByDefault="true"
+                level="WARNING"
+                implementationClass="com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.EndpointOnNonAzureOpenAIAuthCheck">
+
+            <class>
+                com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.EndpointOnNonAzureOpenAIAuthCheck
+            </class>
+        </localInspection>
     </extensions>
 </idea-plugin>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
@@ -211,7 +211,7 @@
         <localInspection
                 language="JAVA"
                 shortName="EndpointOnNonAzureOpenAIAuthCheck"
-                displayName="Endpoint On Non-Azure OpenAI Auth Check"
+                displayName="Endpoint On Non-Azure OpenAI Authentication Check"
                 groupName="Azure SDK"
                 enabledByDefault="true"
                 level="WARNING"

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
@@ -79,7 +79,22 @@
     }
   },
   "SingleOperationInLoopCheck": {
-    "methods_to_check": ["detectLanguageBatch", "recognizeEntitiesBatch", "recognizePiiEntitiesBatch", "recognizeLinkedEntitiesBatch", "extractKeyPhrasesBatch", "analyzeSentimentBatch"],
+    "methods_to_check": [
+      "detectLanguageBatch",
+      "recognizeEntitiesBatch",
+      "recognizePiiEntitiesBatch",
+      "recognizeLinkedEntitiesBatch",
+      "extractKeyPhrasesBatch",
+      "analyzeSentimentBatch"
+    ],
     "anti_pattern_message": "Single operation found in loop. This SDK provides a batch operation API, use it to perform multiple actions in a single request: "
+  },
+  "EndpointOnNonAzureOpenAIAuthCheck": {
+    "methods_to_check": [
+      "endpoint",
+      "credential"
+    ],
+    "services_to_check": "KeyCredential",
+    "anti_pattern_message": "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients"
   }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
@@ -111,11 +111,11 @@
     "solution": "Use the QueryTimeInterval parameter in the client method parameters to specify the time interval for the query"
   },
   "EndpointOnNonAzureOpenAIAuthCheck": {
-    "methods_to_check": [
+    "methodsToCheck": [
       "endpoint",
       "credential"
     ],
-    "services_to_check": "KeyCredential",
-    "anti_pattern_message": "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients"
+    "servicesToCheck": "KeyCredential",
+    "antiPatternMessage": "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients"
   }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheckTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheckTest.java
@@ -2,11 +2,11 @@ package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
 
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.JavaElementVisitor;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiExpression;
 import com.intellij.psi.PsiExpressionList;
-import com.intellij.psi.PsiForStatement;
+import com.intellij.psi.PsiJavaCodeReferenceElement;
 import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.PsiNewExpression;
 import com.intellij.psi.PsiReferenceExpression;
 import com.intellij.psi.PsiType;
 import com.intellij.psi.PsiVariable;
@@ -21,6 +21,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * This class is used to test the EndpointOnNonAzureOpenAIAuthCheck class.
+ * The EndpointOnNonAzureOpenAIAuthCheck class is a LocalInspectionTool that checks if the endpoint method is used with KeyCredential for non-Azure OpenAI clients.
+ * If the endpoint method is used with KeyCredential for non-Azure OpenAI clients, a warning is registered.
+ * An example that should be flagged is:
+ * OpenAI Client client = new OpenAIClientBuilder()
+ * .credential(new KeyCredential("key"))
+ * .endpoint("endpoint")
+ * .buildClient();
+ */
 public class EndpointOnNonAzureOpenAIAuthCheckTest {
 
     // Declare as instance variables
@@ -40,44 +50,60 @@ public class EndpointOnNonAzureOpenAIAuthCheckTest {
         mockMethodCall = mock(PsiMethodCallExpression.class);
     }
 
+    /**
+     * This test checks if the endpoint method is used with KeyCredential for non-Azure OpenAI clients.
+     * If the endpoint method is used with KeyCredential for non-Azure OpenAI clients, a warning is registered.
+     */
     @Test
     public void testEndpointOnNonAzureOpenAIAuthCheck() {
 
         int numOfInvocation = 1;
         String endpoint = "endpoint";
         String credential = "credential";
-        String KeyCredentialPackageName = "com.azure.core.credential.KeyCredential";
+        String KeyCredentialPackageName = "KeyCredential";
         String azurePackageName = "com.azure.ai.openai";
 
         verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
     }
 
+    /**
+     * This test checks if the endpoint method is not used with KeyCredential for non-Azure OpenAI clients.
+     * If the endpoint method is not used with KeyCredential for non-Azure OpenAI clients, no warning is registered.
+     */
     @Test
-    public void testNoEndpoint(){
+    public void testNoEndpoint() {
 
         int numOfInvocation = 0;
         String endpoint = "notEndpoint";
         String credential = "credential";
-        String KeyCredentialPackageName = "com.azure.core.credential.KeyCredential";
+        String KeyCredentialPackageName = "KeyCredential";
         String azurePackageName = "com.azure.ai.openai";
 
         verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
     }
 
+    /**
+     * This test checks if the endpoint method is used but credential is not used.
+     * If the endpoint method is used but credential is not used, no warning is registered.
+     */
     @Test
-    public void testNoCredential(){
+    public void testNoCredential() {
 
         int numOfInvocation = 0;
         String endpoint = "endpoint";
         String credential = "notCredential";
-        String KeyCredentialPackageName = "com.azure.core.credential.KeyCredential";
+        String KeyCredentialPackageName = "KeyCredential";
         String azurePackageName = "com.azure.ai.openai";
 
         verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
     }
 
+    /**
+     * This test checks if the endpoint method is used with KeyCredential but for Azure OpenAI clients.
+     * If the endpoint method is used with KeyCredential but for Azure OpenAI clients, no warning is registered.
+     */
     @Test
-    public void testWithAzureKeyCredential(){
+    public void testWithAzureKeyCredential() {
 
         int numOfInvocation = 0;
         String endpoint = "endpoint";
@@ -88,31 +114,31 @@ public class EndpointOnNonAzureOpenAIAuthCheckTest {
         verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
     }
 
-
-
+    /**
+     * creates a JavaElementVisitor object for visiting method call expressions
+     */
     private JavaElementVisitor createVisitor() {
-        boolean isOnTheFly = true;
-        EndpointOnNonAzureOpenAIAuthVisitor mockVisitor = new EndpointOnNonAzureOpenAIAuthVisitor(mockHolder, isOnTheFly);
-        return mockVisitor;
+        return new EndpointOnNonAzureOpenAIAuthVisitor(mockHolder);
     }
 
-
+    /**
+     * This method verifies if the registerProblem method is called with the correct parameters
+     */
     private void verifyRegisterProblem(int numOfInvocation, String endpoint, String credential, String KeyCredentialPackageName, String azurePackageName) {
-
 
         PsiReferenceExpression methodExpression = mock(PsiReferenceExpression.class);
 
         PsiMethodCallExpression qualifierOne = mock(PsiMethodCallExpression.class);
         PsiReferenceExpression methodExpressionOne = mock(PsiReferenceExpression.class);
 
-        PsiExpression expression = mock(PsiExpression.class);
+        PsiNewExpression newExpression = mock(PsiNewExpression.class);
         PsiExpressionList argumentList = mock(PsiExpressionList.class);
-        PsiExpression[] arguments = new PsiExpression[]{expression};
+        PsiExpression[] arguments = new PsiExpression[]{newExpression};
 
-        PsiType type = mock(PsiType.class);
+        PsiJavaCodeReferenceElement classReference = mock(PsiJavaCodeReferenceElement.class);
+
         PsiVariable parent = mock(PsiVariable.class);
         PsiType qualifierTYpe = mock(PsiType.class);
-
 
         when(mockMethodCall.getMethodExpression()).thenReturn(methodExpression);
         when(methodExpression.getReferenceName()).thenReturn(endpoint);
@@ -127,8 +153,9 @@ public class EndpointOnNonAzureOpenAIAuthCheckTest {
         when(argumentList.getExpressions()).thenReturn(arguments);
 
         // isKeyCredential
-        when(expression.getType()).thenReturn(type);
-        when(type.getCanonicalText()).thenReturn(KeyCredentialPackageName);
+
+        when(newExpression.getClassReference()).thenReturn(classReference);
+        when(classReference.getReferenceName()).thenReturn(KeyCredentialPackageName);
 
         // isNonAzureOpenAIClient
         when(qualifierOne.getParent()).thenReturn(parent);
@@ -138,7 +165,5 @@ public class EndpointOnNonAzureOpenAIAuthCheckTest {
         mockVisitor.visitMethodCallExpression(mockMethodCall);
 
         verify(mockHolder, times(numOfInvocation)).registerProblem(mockMethodCall, "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients");
-
-
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheckTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheckTest.java
@@ -1,0 +1,144 @@
+package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
+
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiExpression;
+import com.intellij.psi.PsiExpressionList;
+import com.intellij.psi.PsiForStatement;
+import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.PsiReferenceExpression;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.PsiVariable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.EndpointOnNonAzureOpenAIAuthCheck.EndpointOnNonAzureOpenAIAuthVisitor;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EndpointOnNonAzureOpenAIAuthCheckTest {
+
+    // Declare as instance variables
+    @Mock
+    private ProblemsHolder mockHolder;
+
+    @Mock
+    private JavaElementVisitor mockVisitor;
+
+    @Mock
+    private PsiMethodCallExpression mockMethodCall;
+
+    @BeforeEach
+    public void setup() {
+        mockHolder = mock(ProblemsHolder.class);
+        mockVisitor = createVisitor();
+        mockMethodCall = mock(PsiMethodCallExpression.class);
+    }
+
+    @Test
+    public void testEndpointOnNonAzureOpenAIAuthCheck() {
+
+        int numOfInvocation = 1;
+        String endpoint = "endpoint";
+        String credential = "credential";
+        String KeyCredentialPackageName = "com.azure.core.credential.KeyCredential";
+        String azurePackageName = "com.azure.ai.openai";
+
+        verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
+    }
+
+    @Test
+    public void testNoEndpoint(){
+
+        int numOfInvocation = 0;
+        String endpoint = "notEndpoint";
+        String credential = "credential";
+        String KeyCredentialPackageName = "com.azure.core.credential.KeyCredential";
+        String azurePackageName = "com.azure.ai.openai";
+
+        verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
+    }
+
+    @Test
+    public void testNoCredential(){
+
+        int numOfInvocation = 0;
+        String endpoint = "endpoint";
+        String credential = "notCredential";
+        String KeyCredentialPackageName = "com.azure.core.credential.KeyCredential";
+        String azurePackageName = "com.azure.ai.openai";
+
+        verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
+    }
+
+    @Test
+    public void testWithAzureKeyCredential(){
+
+        int numOfInvocation = 0;
+        String endpoint = "endpoint";
+        String credential = "notCredential";
+        String KeyCredentialPackageName = "com.azure.core.credential.AzureKeyCredential";
+        String azurePackageName = "com.azure.ai.openai";
+
+        verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
+    }
+
+
+
+    private JavaElementVisitor createVisitor() {
+        boolean isOnTheFly = true;
+        EndpointOnNonAzureOpenAIAuthVisitor mockVisitor = new EndpointOnNonAzureOpenAIAuthVisitor(mockHolder, isOnTheFly);
+        return mockVisitor;
+    }
+
+
+    private void verifyRegisterProblem(int numOfInvocation, String endpoint, String credential, String KeyCredentialPackageName, String azurePackageName) {
+
+
+        PsiReferenceExpression methodExpression = mock(PsiReferenceExpression.class);
+
+        PsiMethodCallExpression qualifierOne = mock(PsiMethodCallExpression.class);
+        PsiReferenceExpression methodExpressionOne = mock(PsiReferenceExpression.class);
+
+        PsiExpression expression = mock(PsiExpression.class);
+        PsiExpressionList argumentList = mock(PsiExpressionList.class);
+        PsiExpression[] arguments = new PsiExpression[]{expression};
+
+        PsiType type = mock(PsiType.class);
+        PsiVariable parent = mock(PsiVariable.class);
+        PsiType qualifierTYpe = mock(PsiType.class);
+
+
+        when(mockMethodCall.getMethodExpression()).thenReturn(methodExpression);
+        when(methodExpression.getReferenceName()).thenReturn(endpoint);
+
+        // isUsingKeyCredential
+        when(methodExpression.getQualifierExpression()).thenReturn(qualifierOne);
+        when(qualifierOne.getMethodExpression()).thenReturn(methodExpressionOne);
+        when(methodExpressionOne.getReferenceName()).thenReturn(credential);
+        when(methodExpressionOne.getQualifierExpression()).thenReturn(null);
+
+        when(qualifierOne.getArgumentList()).thenReturn(argumentList);
+        when(argumentList.getExpressions()).thenReturn(arguments);
+
+        // isKeyCredential
+        when(expression.getType()).thenReturn(type);
+        when(type.getCanonicalText()).thenReturn(KeyCredentialPackageName);
+
+        // isNonAzureOpenAIClient
+        when(qualifierOne.getParent()).thenReturn(parent);
+        when(parent.getType()).thenReturn(qualifierTYpe);
+        when(qualifierTYpe.getCanonicalText()).thenReturn(azurePackageName);
+
+        mockVisitor.visitMethodCallExpression(mockMethodCall);
+
+        verify(mockHolder, times(numOfInvocation)).registerProblem(mockMethodCall, "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients");
+
+
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheckTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/EndpointOnNonAzureOpenAIAuthCheckTest.java
@@ -60,10 +60,10 @@ public class EndpointOnNonAzureOpenAIAuthCheckTest {
         int numOfInvocation = 1;
         String endpoint = "endpoint";
         String credential = "credential";
-        String KeyCredentialPackageName = "KeyCredential";
+        String keyCredentialPackageName = "KeyCredential";
         String azurePackageName = "com.azure.ai.openai";
 
-        verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
+        verifyRegisterProblem(numOfInvocation, endpoint, credential, keyCredentialPackageName, azurePackageName);
     }
 
     /**
@@ -76,10 +76,10 @@ public class EndpointOnNonAzureOpenAIAuthCheckTest {
         int numOfInvocation = 0;
         String endpoint = "notEndpoint";
         String credential = "credential";
-        String KeyCredentialPackageName = "KeyCredential";
+        String keyCredentialPackageName = "KeyCredential";
         String azurePackageName = "com.azure.ai.openai";
 
-        verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
+        verifyRegisterProblem(numOfInvocation, endpoint, credential, keyCredentialPackageName, azurePackageName);
     }
 
     /**
@@ -92,10 +92,10 @@ public class EndpointOnNonAzureOpenAIAuthCheckTest {
         int numOfInvocation = 0;
         String endpoint = "endpoint";
         String credential = "notCredential";
-        String KeyCredentialPackageName = "KeyCredential";
+        String keyCredentialPackageName = "KeyCredential";
         String azurePackageName = "com.azure.ai.openai";
 
-        verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
+        verifyRegisterProblem(numOfInvocation, endpoint, credential, keyCredentialPackageName, azurePackageName);
     }
 
     /**
@@ -108,10 +108,10 @@ public class EndpointOnNonAzureOpenAIAuthCheckTest {
         int numOfInvocation = 0;
         String endpoint = "endpoint";
         String credential = "notCredential";
-        String KeyCredentialPackageName = "com.azure.core.credential.AzureKeyCredential";
+        String keyCredentialPackageName = "com.azure.core.credential.AzureKeyCredential";
         String azurePackageName = "com.azure.ai.openai";
 
-        verifyRegisterProblem(numOfInvocation, endpoint, credential, KeyCredentialPackageName, azurePackageName);
+        verifyRegisterProblem(numOfInvocation, endpoint, credential, keyCredentialPackageName, azurePackageName);
     }
 
     /**
@@ -124,7 +124,7 @@ public class EndpointOnNonAzureOpenAIAuthCheckTest {
     /**
      * This method verifies if the registerProblem method is called with the correct parameters
      */
-    private void verifyRegisterProblem(int numOfInvocation, String endpoint, String credential, String KeyCredentialPackageName, String azurePackageName) {
+    private void verifyRegisterProblem(int numOfInvocation, String endpoint, String credential, String keyCredentialPackageName, String azurePackageName) {
 
         PsiReferenceExpression methodExpression = mock(PsiReferenceExpression.class);
 
@@ -155,7 +155,7 @@ public class EndpointOnNonAzureOpenAIAuthCheckTest {
         // isKeyCredential
 
         when(newExpression.getClassReference()).thenReturn(classReference);
-        when(classReference.getReferenceName()).thenReturn(KeyCredentialPackageName);
+        when(classReference.getReferenceName()).thenReturn(keyCredentialPackageName);
 
         // isNonAzureOpenAIClient
         when(qualifierOne.getParent()).thenReturn(parent);


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
 This class is a LocalInspectionTool that checks if the endpoint method is used with KeyCredential for non-Azure OpenAI clients.
 If the endpoint method is used with KeyCredential for non-Azure OpenAI clients, a warning is registered.

Has this been tested?
---------------------------
- [x] Tested

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
![image](https://github.com/user-attachments/assets/f3ec1a2f-72db-4c2c-9c52-9b3e4dc81365)