### PR TITLE
Stop then start on servicebus processor

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
@@ -247,3 +247,13 @@ integration, telemetry connectivity, and Azure Toolkit integration.
   Please refer to
   the [QueryTimeInterval Class documentation](https://learn.microsoft.com/java/api/com.azure.monitor.query.models.querytimeinterval?view=azure-java-stable)
   for additional information.
+
+13. #### Calling 'stop' then 'start' APIs on a ServiceBusProcessor Client
+
+- **Anti-pattern**: Calling `stop()` followed by `start()` on a `ServiceBusProcessorClient` instance.
+- **Issue**: Calling `stop()` followed by `start()` on a `ServiceBusProcessorClient` involves significant complexity and
+  may
+  be deprecated in future versions of the SDK.
+- **Severity: WARNING**
+- **Recommendation**: Please close this processor instance and create a new one to restart processing. Refer to
+  the [GitHub issue](https://github.com/Azure/azure-sdk-for-java/issues/34464) for more details

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheck.java
@@ -3,9 +3,16 @@ package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
 import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiAssignmentExpression;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiCodeBlock;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiExpression;
+import com.intellij.psi.PsiExpressionStatement;
+import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.PsiNewExpression;
+import com.intellij.psi.PsiParameter;
 import com.intellij.psi.PsiReferenceExpression;
 import com.intellij.psi.PsiType;
 import com.intellij.psi.PsiVariable;
@@ -44,7 +51,7 @@ public class StopThenStartOnServiceBusProcessorCheck extends LocalInspectionTool
         private final ProblemsHolder holder;
 
         // Create a map to store a boolean indicating if stop was called on the variable
-        private final Map<PsiVariable, Boolean> variableStateMap = new HashMap<>();
+        private final Map<Integer, Boolean> variableStateMap = new HashMap<>();
 
         // Define constants for string literals
         private static final RuleConfig RULE_CONFIG;
@@ -70,22 +77,137 @@ public class StopThenStartOnServiceBusProcessorCheck extends LocalInspectionTool
         }
 
         /**
+         * @param element
+         */
+        @Override
+        public void visitElement(@NotNull PsiElement element) {
+            super.visitElement(element);
+
+            // check if there's been a new expression
+            if (SKIP_WHOLE_RULE) {
+                return;
+            }
+
+            if (element instanceof PsiNewExpression) {
+                PsiNewExpression newExpression = (PsiNewExpression) element;
+                System.out.println("New Expression: " + newExpression);
+
+                PsiVariable associatedVariable = findAssociatedVariable(newExpression);
+                System.out.println("Associated Variable: " + associatedVariable);
+
+                if (associatedVariable != null && isServiceBusProcessorClient(associatedVariable)) {
+                    variableStateMap.put(associatedVariable.hashCode(), false);
+                    System.out.println("Associated Variable: " + associatedVariable.getName());
+                    System.out.println("AssociatedVariable.hashCode(): " + associatedVariable.hashCode());
+                } else {
+                    System.out.println("No associated variable found.");
+                }
+            }
+
+            // if a method is found, check its body
+            if (element instanceof PsiMethod) {
+                PsiMethod method = (PsiMethod) element;
+                System.out.println("Method: " + method);
+
+                PsiCodeBlock body = method.getBody();
+                System.out.println("Body: " + body);
+
+                if (body != null) {
+                    visitMethodBody(body);  // Start visiting the body elements
+                }
+            }
+        }
+
+        // Recursively visit all elements in a method body
+        private void visitMethodBody(@NotNull PsiCodeBlock body) {
+
+            for (PsiElement child : body.getChildren()) {
+
+                System.out.println("Child: " + child);
+
+                // If the child is a method call, resolve it
+                if (child instanceof PsiExpressionStatement) {
+
+                    System.out.println("Expression Statement: " + child);
+
+                    PsiExpression expression = ((PsiExpressionStatement) child).getExpression();
+                    System.out.println("Expression: " + expression);
+
+                    if (!(expression instanceof PsiMethodCallExpression)) {
+                        continue;
+                    }
+
+                    // Handle the method call
+                    PsiMethodCallExpression methodCall = (PsiMethodCallExpression) expression;
+                    System.out.println("Method Call: " + methodCall);
+
+                    // check the element being called on
+                    PsiElement element = methodCall.getMethodExpression().getQualifierExpression();
+                    System.out.println("Element: " + element);
+
+                    if (element instanceof PsiReferenceExpression) {
+                        PsiReferenceExpression reference = (PsiReferenceExpression) element;
+                        System.out.println("Reference: " + reference);
+
+                        PsiElement resolvedElement = reference.resolve();
+                        System.out.println("Resolved Element: " + resolvedElement);
+                        System.out.println("resolvedElement.hashCode(): " + resolvedElement.hashCode());
+
+                        // Check if the resolved element is a variable
+                        if ((resolvedElement instanceof PsiVariable)) {
+                            PsiVariable variable = (PsiVariable) resolvedElement;
+                            System.out.println("Variable: " + variable);
+                            System.out.println("Variable Name: " + variable.getName());
+                            System.out.println("Variable Type: " + variable.getType());
+                            System.out.println("Variable getNameIdentifier: " + variable.getNameIdentifier());
+                            System.out.println("Variable getParent: " + variable.getParent());
+                            System.out.println("Variable getIdentifyingElement: " + variable.getIdentifyingElement());
+                            System.out.println("Variable State Map: " + variableStateMap);
+
+                            if (variableStateMap.containsKey(resolvedElement.hashCode())) {
+                                checkMethodCall(methodCall);
+                                continue;
+                            }
+                        }
+                    }
+
+                    // Resolve the method call to its method definition
+                    PsiMethod resolvedMethod = methodCall.resolveMethod();
+
+                    if (resolvedMethod != null) {
+                        System.out.println("Resolved Method: " + resolvedMethod);
+
+                        PsiCodeBlock resolvedBody = resolvedMethod.getBody();
+                        System.out.println("Resolved Body: " + resolvedBody);
+                        if (resolvedBody != null) {
+                            visitMethodBody(resolvedBody);  // Recursively visit the resolved method's body
+                        }
+                    }
+                }
+
+                // Continue visiting children of the current element
+                child.accept(this);
+            }
+        }
+
+
+        /**
          * This method visits the PsiMethodCallExpression and checks if a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on the same object.
          * If this is the case, a problem is registered with the ProblemsHolder.
          *
          * @param expression The PsiMethodCallExpression to visit
          */
-        @Override
-        public void visitMethodCallExpression(@NotNull PsiMethodCallExpression expression) {
-            super.visitMethodCallExpression(expression);
+        private void checkMethodCall(PsiMethodCallExpression expression) {
 
-            if (SKIP_WHOLE_RULE) {
-                return;
-            }
+            System.out.println("checkMethodCall");
 
             // Check if the method being called is 'stop' or 'start'
             PsiReferenceExpression methodExpression = expression.getMethodExpression();
             String methodName = methodExpression.getReferenceName();
+
+            System.out.println("Method Name: " + methodName);
+
+            System.out.println("Methods to Check: " + RULE_CONFIG.getMethodsToCheck());
 
             if (!(RULE_CONFIG.getMethodsToCheck().contains(methodName))) {
                 return;
@@ -93,34 +215,35 @@ public class StopThenStartOnServiceBusProcessorCheck extends LocalInspectionTool
 
             // Get the qualifier of the method call - the object on which the method is called
             PsiExpression qualifier = methodExpression.getQualifierExpression();
+            System.out.println("Qualifier: " + qualifier);
 
             if (!(qualifier instanceof PsiReferenceExpression)) {
                 return;
             }
             PsiElement reference = ((PsiReferenceExpression) qualifier).resolve();
+            System.out.println("Reference: " + reference);
 
-            if (!(reference instanceof PsiVariable)) {
-                return;
-            }
+//            if (!(reference instanceof PsiVariable)) {
+//                return;
+//            }
 
             // Get the variable that the method is called on
             PsiVariable variable = (PsiVariable) reference;
-
-            // Check if the variable is a ServiceBusProcessorClient
-            if (!(isServiceBusProcessorClient(variable))) {
-                return;
-            }
+            System.out.println("VariableInCheckMethod: " + variable);
 
             // Boolean indicating if stop was called on the variable
-            Boolean wasStopCalled = variableStateMap.get(variable);
+            Boolean wasStopCalled = variableStateMap.get(variable.hashCode());
+            System.out.println("Was Stop Called: " + wasStopCalled);
 
             // If 'stop' is called, mark that 'stop' was called on the variable
             if ("stop".equals(methodName)) {
-                variableStateMap.put(variable, true); // Mark that stop was called
+                System.out.println("Stop Method Called");
+                System.out.println("Variable Hash Code: " + variable.hashCode());
+                variableStateMap.put(variable.hashCode(), true); // Mark that stop was called
 
                 // If 'start' is called and 'stop' was called on the variable, register a problem
             } else if ("start".equals(methodName) && Boolean.TRUE.equals(wasStopCalled)) {
-                holder.registerProblem(expression, RULE_CONFIG.getAntiPatternMessageMap().get("antiPatternMessage"));
+                holder.registerProblem(methodExpression, RULE_CONFIG.getAntiPatternMessageMap().get("antiPatternMessage"));
 
                 // Reset the state after reporting the problem
                 variableStateMap.remove(variable);
@@ -138,6 +261,48 @@ public class StopThenStartOnServiceBusProcessorCheck extends LocalInspectionTool
             PsiType type = variable.getType();
             String typeText = type.getCanonicalText();
             return typeText != null && typeText.contains(RULE_CONFIG.getClientsToCheck().get(0)) && typeText.startsWith(RuleConfig.AZURE_PACKAGE_NAME);
+        }
+
+        /**
+         * Finds the variable associated with a PsiNewExpression.
+         *
+         * @param newExpression The PsiNewExpression instance.
+         * @return The associated PsiVariable or null if not found.
+         */
+        public PsiVariable findAssociatedVariable(PsiNewExpression newExpression) {
+            System.out.println("New Expression: " + newExpression);
+
+            PsiElement parent = newExpression.getParent();
+            System.out.println("Parent: " + parent);
+
+            // Traverse upwards to find a variable declaration or assignment
+            while (parent != null) {
+                if (parent instanceof PsiVariable) {
+                    return (PsiVariable) parent; // Direct variable initialization
+                } else if (parent instanceof PsiAssignmentExpression) {
+                    PsiAssignmentExpression assignmentExpression = (PsiAssignmentExpression) parent;
+                    System.out.println("Assignment Expression: " + assignmentExpression);
+
+                    PsiExpression lhs = assignmentExpression.getLExpression();
+                    System.out.println("LHS: " + lhs);
+
+                    if (lhs instanceof PsiReferenceExpression) {
+                        PsiReferenceExpression referenceExpression = (PsiReferenceExpression) lhs;
+                        System.out.println("Reference Expression: " + referenceExpression);
+
+                        PsiElement resolvedElement = referenceExpression.resolve();
+                        System.out.println("Resolved Element: " + resolvedElement);
+
+                        if (resolvedElement instanceof PsiVariable) {
+                            return (PsiVariable) resolvedElement; // Variable in assignment
+                        }
+                    }
+                }
+                // Move up the tree
+                parent = parent.getParent();
+                System.out.println("Parent: " + parent);
+            }
+            return null; // No associated variable found
         }
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheck.java
@@ -1,0 +1,129 @@
+package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
+
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiCodeBlock;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiExpression;
+import com.intellij.psi.PsiLambdaExpression;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.PsiReferenceExpression;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.PsiVariable;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class StopThenStartOnServiceBusProcessorCheck extends LocalInspectionTool {
+
+    @NotNull
+    @Override
+    public JavaElementVisitor buildVisitor(@NotNull ProblemsHolder holder, boolean isOnTheFly) {
+        return new StopThenStartOnServiceBusProcessorVisitor(holder);
+    }
+
+
+    static class StopThenStartOnServiceBusProcessorVisitor extends JavaElementVisitor {
+
+        private final ProblemsHolder holder;
+        private final Map<PsiVariable, Boolean> variableStateMap = new HashMap<>();
+
+        // // Define constants for string literals
+        private static final RuleConfig RULE_CONFIG;
+        private static final boolean SKIP_WHOLE_RULE;
+
+        static {
+            final String ruleName = "StopThenStartOnServiceBusProcessorCheck";
+            RuleConfigLoader centralRuleConfigLoader = RuleConfigLoader.getInstance();
+
+            // Get the RuleConfig object for the rule
+            RULE_CONFIG = centralRuleConfigLoader.getRuleConfig(ruleName);
+            SKIP_WHOLE_RULE = RULE_CONFIG.skipRuleCheck() || RULE_CONFIG.getClientsToCheck().isEmpty();
+
+            System.out.println("RULE_CONFIG: " + RULE_CONFIG);
+            System.out.println("SKIP_WHOLE_RULE: " + SKIP_WHOLE_RULE);
+            System.out.println("RULE_CONFIG.getMethodsToCheck(): " + RULE_CONFIG.getMethodsToCheck());
+            System.out.println("RULE_CONFIG.getClientsToCheck(): " + RULE_CONFIG.getClientsToCheck());
+            System.out.println("RULE_CONFIG.getAntiPatternMessageMap(): " + RULE_CONFIG.getAntiPatternMessageMap());
+        }
+
+
+        StopThenStartOnServiceBusProcessorVisitor(ProblemsHolder holder) {
+            this.holder = holder;
+        }
+
+
+        @Override
+        public void visitMethodCallExpression(@NotNull PsiMethodCallExpression expression) {
+            super.visitMethodCallExpression(expression);
+
+
+            // Check if the method being called is 'stop' or 'start'
+            PsiReferenceExpression methodExpression = expression.getMethodExpression();
+            System.out.println("methodExpression: " + methodExpression);
+
+            String methodName = methodExpression.getReferenceName();
+            System.out.println("methodName: " + methodName);
+
+            if (RULE_CONFIG.getMethodsToCheck().contains(methodName)) {
+                PsiExpression qualifier = methodExpression.getQualifierExpression();
+                System.out.println("qualifier: " + qualifier);
+
+                if (qualifier instanceof PsiReferenceExpression) {
+                    PsiElement reference = ((PsiReferenceExpression) qualifier).resolve();
+                    System.out.println("reference: " + reference);
+
+                    if (reference instanceof PsiVariable) {
+                        PsiVariable variable = (PsiVariable) reference;
+                        System.out.println("variable: " + variable);
+
+                        // Check if the variable is a ServiceBusProcessorClient
+                        if (isServiceBusProcessorClient(variable)) {
+                            System.out.println("ServiceBusProcessorClient found");
+
+                            if (isServiceBusProcessorClient(variable)) {
+                                Boolean wasStopCalled = variableStateMap.get(variable);
+                                System.out.println("wasStopCalled: " + wasStopCalled);
+
+                                if ("stop".equals(methodName)) {
+                                    System.out.println("stop called");
+                                    variableStateMap.put(variable, true); // Mark that stop was called
+                                    System.out.println("variableStateMapBeforeStop: " + variableStateMap);
+                                } else if ("close".equals(methodName)) {
+                                    System.out.println("close called");
+                                    variableStateMap.remove(variable); // Remove the variable from the map
+                                    System.out.println("variableStateMapBeforeClose: " + variableStateMap);
+
+                                } else if ("start".equals(methodName) && Boolean.TRUE.equals(wasStopCalled)) {
+                                    System.out.println("Problem is registered");
+                                    System.out.println("variableStateMapBeforeProblemRegistered: " + variableStateMap);
+                                    holder.registerProblem(expression, RULE_CONFIG.getAntiPatternMessageMap().get("antiPatternMessage"));
+
+                                    // Reset the state after reporting
+                                    variableStateMap.remove(variable);
+                                    System.out.println("variableStateMapAfterProblemRegistered: " + variableStateMap);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private boolean isServiceBusProcessorClient(PsiVariable variable) {
+            // Check if the type of the variable is ServiceBusProcessorClient
+            PsiType type = variable.getType();
+            String typeText = type.getCanonicalText();
+            System.out.println("typeText: " + typeText);
+            System.out.println("RULE_CONFIG.getClientsToCheck().get(0): " + RULE_CONFIG.getClientsToCheck().get(0));
+            System.out.println("type" + type);
+            return typeText != null && typeText.contains(RULE_CONFIG.getClientsToCheck().get(0)) && typeText.startsWith(RuleConfig.AZURE_PACKAGE_NAME);
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheck.java
@@ -3,41 +3,54 @@ package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
 import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.JavaElementVisitor;
-import com.intellij.psi.PsiCodeBlock;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiExpression;
-import com.intellij.psi.PsiLambdaExpression;
-import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiMethodCallExpression;
-import com.intellij.psi.PsiReference;
 import com.intellij.psi.PsiReferenceExpression;
 import com.intellij.psi.PsiType;
 import com.intellij.psi.PsiVariable;
-import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * This class is a LocalInspectionTool that checks if a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on the same object.
+ * If this is the case, a problem is registered with the ProblemsHolder.
+ */
 public class StopThenStartOnServiceBusProcessorCheck extends LocalInspectionTool {
 
+    /**
+     * This method builds a visitor that visits the PsiMethodCallExpression and checks if a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on the same object.
+     * If this is the case, a problem is registered with the ProblemsHolder.
+     *
+     * @param holder     The ProblemsHolder to register the problem with
+     * @param isOnTheFly A boolean that indicates if the inspection is being run on the fly - not used in this implementation but required by the method signature
+     * @return A JavaElementVisitor that visits the PsiMethodCallExpression and checks if a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on the same object
+     */
     @NotNull
     @Override
     public JavaElementVisitor buildVisitor(@NotNull ProblemsHolder holder, boolean isOnTheFly) {
         return new StopThenStartOnServiceBusProcessorVisitor(holder);
     }
 
-
+    /**
+     * This class is a JavaElementVisitor that visits the PsiMethodCallExpression and checks if a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on the same object.
+     * If this is the case, a problem is registered with the ProblemsHolder.
+     */
     static class StopThenStartOnServiceBusProcessorVisitor extends JavaElementVisitor {
 
+        // Create a ProblemsHolder to register the problem with
         private final ProblemsHolder holder;
+
+        // Create a map to store a boolean indicating if stop was called on the variable
         private final Map<PsiVariable, Boolean> variableStateMap = new HashMap<>();
 
-        // // Define constants for string literals
+        // Define constants for string literals
         private static final RuleConfig RULE_CONFIG;
         private static final boolean SKIP_WHOLE_RULE;
 
+        // Load the rule configuration
         static {
             final String ruleName = "StopThenStartOnServiceBusProcessorCheck";
             RuleConfigLoader centralRuleConfigLoader = RuleConfigLoader.getInstance();
@@ -45,84 +58,89 @@ public class StopThenStartOnServiceBusProcessorCheck extends LocalInspectionTool
             // Get the RuleConfig object for the rule
             RULE_CONFIG = centralRuleConfigLoader.getRuleConfig(ruleName);
             SKIP_WHOLE_RULE = RULE_CONFIG.skipRuleCheck() || RULE_CONFIG.getClientsToCheck().isEmpty();
-
-            System.out.println("RULE_CONFIG: " + RULE_CONFIG);
-            System.out.println("SKIP_WHOLE_RULE: " + SKIP_WHOLE_RULE);
-            System.out.println("RULE_CONFIG.getMethodsToCheck(): " + RULE_CONFIG.getMethodsToCheck());
-            System.out.println("RULE_CONFIG.getClientsToCheck(): " + RULE_CONFIG.getClientsToCheck());
-            System.out.println("RULE_CONFIG.getAntiPatternMessageMap(): " + RULE_CONFIG.getAntiPatternMessageMap());
         }
 
-
+        /**
+         * This constructor initializes the Visitor with the ProblemsHolder
+         *
+         * @param holder The ProblemsHolder to register the problem with
+         */
         StopThenStartOnServiceBusProcessorVisitor(ProblemsHolder holder) {
             this.holder = holder;
         }
 
-
+        /**
+         * This method visits the PsiMethodCallExpression and checks if a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on the same object.
+         * If this is the case, a problem is registered with the ProblemsHolder.
+         *
+         * @param expression The PsiMethodCallExpression to visit
+         */
         @Override
         public void visitMethodCallExpression(@NotNull PsiMethodCallExpression expression) {
             super.visitMethodCallExpression(expression);
 
+            if (SKIP_WHOLE_RULE) {
+                return;
+            }
 
             // Check if the method being called is 'stop' or 'start'
             PsiReferenceExpression methodExpression = expression.getMethodExpression();
-            System.out.println("methodExpression: " + methodExpression);
-
             String methodName = methodExpression.getReferenceName();
-            System.out.println("methodName: " + methodName);
 
-            if (RULE_CONFIG.getMethodsToCheck().contains(methodName)) {
-                PsiExpression qualifier = methodExpression.getQualifierExpression();
-                System.out.println("qualifier: " + qualifier);
+            if (!(RULE_CONFIG.getMethodsToCheck().contains(methodName))) {
+                return;
+            }
 
-                if (qualifier instanceof PsiReferenceExpression) {
-                    PsiElement reference = ((PsiReferenceExpression) qualifier).resolve();
-                    System.out.println("reference: " + reference);
+            // Get the qualifier of the method call - the object on which the method is called
+            PsiExpression qualifier = methodExpression.getQualifierExpression();
 
-                    if (reference instanceof PsiVariable) {
-                        PsiVariable variable = (PsiVariable) reference;
-                        System.out.println("variable: " + variable);
+            if (!(qualifier instanceof PsiReferenceExpression)) {
+                return;
+            }
+            PsiElement reference = ((PsiReferenceExpression) qualifier).resolve();
 
-                        // Check if the variable is a ServiceBusProcessorClient
-                        if (isServiceBusProcessorClient(variable)) {
-                            System.out.println("ServiceBusProcessorClient found");
+            if (!(reference instanceof PsiVariable)) {
+                return;
+            }
 
-                            if (isServiceBusProcessorClient(variable)) {
-                                Boolean wasStopCalled = variableStateMap.get(variable);
-                                System.out.println("wasStopCalled: " + wasStopCalled);
+            // Get the variable that the method is called on
+            PsiVariable variable = (PsiVariable) reference;
 
-                                if ("stop".equals(methodName)) {
-                                    System.out.println("stop called");
-                                    variableStateMap.put(variable, true); // Mark that stop was called
-                                    System.out.println("variableStateMapBeforeStop: " + variableStateMap);
-                                } else if ("close".equals(methodName)) {
-                                    System.out.println("close called");
-                                    variableStateMap.remove(variable); // Remove the variable from the map
-                                    System.out.println("variableStateMapBeforeClose: " + variableStateMap);
+            // Check if the variable is a ServiceBusProcessorClient
+            if (!(isServiceBusProcessorClient(variable))) {
+                return;
+            }
 
-                                } else if ("start".equals(methodName) && Boolean.TRUE.equals(wasStopCalled)) {
-                                    System.out.println("Problem is registered");
-                                    System.out.println("variableStateMapBeforeProblemRegistered: " + variableStateMap);
-                                    holder.registerProblem(expression, RULE_CONFIG.getAntiPatternMessageMap().get("antiPatternMessage"));
+            // Boolean indicating if stop was called on the variable
+            Boolean wasStopCalled = variableStateMap.get(variable);
 
-                                    // Reset the state after reporting
-                                    variableStateMap.remove(variable);
-                                    System.out.println("variableStateMapAfterProblemRegistered: " + variableStateMap);
-                                }
-                            }
-                        }
-                    }
-                }
+            // If 'stop' is called, mark that 'stop' was called on the variable
+            if ("stop".equals(methodName)) {
+                variableStateMap.put(variable, true); // Mark that stop was called
+
+                // If 'close' is called, remove the variable from the map -- the resource is closed and the variable is no longer in use
+            } else if ("close".equals(methodName)) {
+                variableStateMap.remove(variable); // Remove the variable from the map
+
+                // If 'start' is called and 'stop' was called on the variable, register a problem
+            } else if ("start".equals(methodName) && Boolean.TRUE.equals(wasStopCalled)) {
+                holder.registerProblem(expression, RULE_CONFIG.getAntiPatternMessageMap().get("antiPatternMessage"));
+
+                // Reset the state after reporting the problem
+                variableStateMap.remove(variable);
             }
         }
 
-        private boolean isServiceBusProcessorClient(PsiVariable variable) {
-            // Check if the type of the variable is ServiceBusProcessorClient
+        /**
+         * This method checks if the type of the variable is ServiceBusProcessorClient
+         *
+         * @param variable The variable to check
+         * @return A boolean indicating if the type of the variable is ServiceBusProcessorClient
+         */
+        private static boolean isServiceBusProcessorClient(PsiVariable variable) {
+
             PsiType type = variable.getType();
             String typeText = type.getCanonicalText();
-            System.out.println("typeText: " + typeText);
-            System.out.println("RULE_CONFIG.getClientsToCheck().get(0): " + RULE_CONFIG.getClientsToCheck().get(0));
-            System.out.println("type" + type);
             return typeText != null && typeText.contains(RULE_CONFIG.getClientsToCheck().get(0)) && typeText.startsWith(RuleConfig.AZURE_PACKAGE_NAME);
         }
     }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheck.java
@@ -118,10 +118,6 @@ public class StopThenStartOnServiceBusProcessorCheck extends LocalInspectionTool
             if ("stop".equals(methodName)) {
                 variableStateMap.put(variable, true); // Mark that stop was called
 
-                // If 'close' is called, remove the variable from the map -- the resource is closed and the variable is no longer in use
-            } else if ("close".equals(methodName)) {
-                variableStateMap.remove(variable); // Remove the variable from the map
-
                 // If 'start' is called and 'stop' was called on the variable, register a problem
             } else if ("start".equals(methodName) && Boolean.TRUE.equals(wasStopCalled)) {
                 holder.registerProblem(expression, RULE_CONFIG.getAntiPatternMessageMap().get("antiPatternMessage"));

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
@@ -207,5 +207,16 @@
                 implementationClass="com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.KustoQueriesWithTimeIntervalInQueryStringCheck">
             <class>com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.KustoQueriesWithTimeIntervalInQueryStringCheck</class>
         </localInspection>
+
+        <localInspection
+                language="JAVA"
+                shortName="StopThenStartOnServiceBusProcessorCheck"
+                displayName="Stop Then Start On ServiceBusProcessor Check"
+                groupName="Azure SDK Rules"
+                enabledByDefault="true"
+                level="WARNING"
+                implementationClass="com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.StopThenStartOnServiceBusProcessorCheck">
+            <class>com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.StopThenStartOnServiceBusProcessorCheck</class>
+        </localInspection>
     </extensions>
 </idea-plugin>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
@@ -113,5 +113,14 @@
     },
     "antiPatternMessage": "KQL queries with time intervals in the query string detected.",
     "solution": "Use the QueryTimeInterval parameter in the client method parameters to specify the time interval for the query"
+  },
+  "StopThenStartOnServiceBusProcessorCheck": {
+    "methodsToCheck": [
+      "stop",
+      "start",
+      "close"
+    ],
+    "clientsToCheck": "ServiceBusProcessorClient",
+    "antiPatternMessage": "Starting Processor that was stopped before is not recommended, and this feature may be deprecated in the future. Please close this processor instance and create a new one to restart processing"
   }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheckTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheckTest.java
@@ -1,11 +1,13 @@
 package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
 
 import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.psi.PsiAssignmentExpression;
 import com.intellij.psi.PsiCodeBlock;
+import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiExpressionStatement;
 import com.intellij.psi.PsiFile;
@@ -282,6 +284,9 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
         PsiExpressionStatement otherChild = mock(PsiExpressionStatement.class);
         PsiElement[] otherChildren = new PsiElement[]{otherChild};
 
+        Document document = mock(Document.class);
+        PsiDocumentManager psiDocumentManager = mock(PsiDocumentManager.class);
+
         // findAssociatedVariable method
         if (directVariableInitialization) {
             when(newExpression.getParent()).thenReturn(findAssociatedVariable);
@@ -329,11 +334,18 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
         // isFileInCurrentProject method
         when(helperMethod.getContainingFile()).thenReturn(containingFile);
         when(containingFile.getProject()).thenReturn(project);
-        when(projectRootManager.getInstance(project)).thenReturn(projectRootManager);
+        when(ProjectRootManager.getInstance(project)).thenReturn(projectRootManager);
         when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
         when(projectFileIndex.isInContent(containingFile.getVirtualFile())).thenReturn(true);
 
         when(helperMethod.getBody()).thenReturn(secondBody);
+
+        // Checking for duplicate registered problems
+        when(startQualifierExpression.getContainingFile()).thenReturn(containingFile);
+        when(PsiDocumentManager.getInstance(project)).thenReturn(psiDocumentManager);
+        when(psiDocumentManager.getDocument(containingFile)).thenReturn(document);
+        when(startMethodExpression.getTextOffset()).thenReturn(1);
+        when(document.getLineNumber(startMethodExpression.getTextOffset())).thenReturn(1);
 
         mockVisitor.visitElement(newExpression);
         mockVisitor.visitMethod(method);

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheckTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheckTest.java
@@ -1,7 +1,17 @@
 package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
 
 import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.psi.PsiAssignmentExpression;
+import com.intellij.psi.PsiCodeBlock;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiExpressionStatement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.PsiNewExpression;
 import com.intellij.psi.PsiReferenceExpression;
 import com.intellij.psi.PsiType;
 import com.intellij.psi.PsiVariable;
@@ -18,8 +28,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * This class tests the StopThenStartOnServiceBusProcessorCheck class
+ */
 public class StopThenStartOnServiceBusProcessorCheckTest {
-
 
     // Create a mock ProblemsHolder to be used in the test
     @Mock
@@ -29,7 +41,6 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
     @Mock
     private StopThenStartOnServiceBusProcessorVisitor mockVisitor;
 
-
     @BeforeEach
     public void setUp() {
         // Set up the test
@@ -38,68 +49,164 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
     }
 
     /**
-     * If a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on the same object
-     * the test should register a problem with the ProblemsHolder
+     * This test case tests the StopThenStartOnServiceBusProcessorCheck class when `stop` is called before `start`
+     * on the same variable in the same method body without recursion.
+     * The test case should register a problem with the ProblemsHolder.
      */
     @Test
-    public void testStopThenStart() {
-
+    public void testSameVariableNonRecursiveStopThenStart() {
         String stopMethod = "stop";
-        boolean isStopMethod = true;
-
         String startMethod = "start";
-        boolean isStartMethod = true;
-
         String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
         int numOfInvocations = 1;
 
         boolean sameVariable = true;
+        boolean recursiveSecondLevel = false;
+        boolean isStopThenStart = true;
+        boolean directVariableInitialization = false;
 
-        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, numOfInvocations, sameVariable);
+        verifyRegisterProblem(stopMethod, startMethod, isStopThenStart, packageName, numOfInvocations, sameVariable, recursiveSecondLevel, directVariableInitialization);
     }
 
     /**
-     * If a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on a different object of the same type
-     * the test should not register a problem with the ProblemsHolder
+     * This test case tests the StopThenStartOnServiceBusProcessorCheck class when 'start' is not called after 'stop'
+     * on the same variable in a different method body with recursion.
+     * The test case should not register a problem with the ProblemsHolder.
      */
     @Test
-    public void testStopStartDifferentVariables() {
-
+    public void testSameVariableNonRecursiveStartThenStop() {
         String stopMethod = "stop";
-        boolean isStopMethod = true;
-
         String startMethod = "start";
-        boolean isStartMethod = true;
+        String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
+        int numOfInvocations = 0;
 
+        boolean sameVariable = true;
+        boolean recursiveSecondLevel = true;
+        boolean isStopThenStart = false;
+        boolean directVariableInitialization = true;
+
+        verifyRegisterProblem(stopMethod, startMethod, isStopThenStart, packageName, numOfInvocations, sameVariable, recursiveSecondLevel, directVariableInitialization);
+    }
+
+    /**
+     * This test case tests the StopThenStartOnServiceBusProcessorCheck class when `stop` is called before `start`
+     * on different variables in the same method body without recursion.
+     * The test case should not register a problem with the ProblemsHolder.
+     */
+    @Test
+    public void testDifferentVariablesNonRecursiveStopThenStart() {
+        String stopMethod = "stop";
+        String startMethod = "start";
         String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
         int numOfInvocations = 0;
 
         boolean sameVariable = false;
+        boolean recursiveSecondLevel = false;
+        boolean isStopThenStart = true;
+        boolean directVariableInitialization = false;
 
-        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, numOfInvocations, sameVariable);
+        verifyRegisterProblem(stopMethod, startMethod, isStopThenStart, packageName, numOfInvocations, sameVariable, recursiveSecondLevel, directVariableInitialization);
     }
 
     /**
-     * If a stop method is called on a different client service, even if the start method is called on the same client service
-     * the test should not register a problem with the ProblemsHolder
+     * This test case tests the StopThenStartOnServiceBusProcessorCheck class when 'start' is not called after 'stop'
+     * on different variables in the same method body with recursion.
+     * The test case should not register a problem with the ProblemsHolder.
      */
     @Test
-    public void testStopThenStartDifferentService() {
-
+    public void testDifferentVariablesNonRecursiveStartThenStop() {
         String stopMethod = "stop";
-        boolean isStopMethod = true;
-
         String startMethod = "start";
-        boolean isStartMethod = true;
+        String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
+        int numOfInvocations = 0;
 
-        String packageName = "com.azure.messaging.servicebus.ServiceBusReceiverAsyncClient";
+        boolean sameVariable = false;
+        boolean recursiveSecondLevel = true;
+        boolean isStopThenStart = false;
+        boolean directVariableInitialization = true;
+
+        verifyRegisterProblem(stopMethod, startMethod, isStopThenStart, packageName, numOfInvocations, sameVariable, recursiveSecondLevel, directVariableInitialization);
+    }
+
+    /**
+     * This test case tests the StopThenStartOnServiceBusProcessorCheck class when `stop` is called before `start`
+     * on the same variable in a recursive second level method.
+     * The test case should register a problem with the ProblemsHolder.
+     */
+    @Test
+    public void testSameVariableRecursiveStopThenStart() {
+        String stopMethod = "stop";
+        String startMethod = "start";
+        String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
+        int numOfInvocations = 1;
+
+        boolean sameVariable = true;
+        boolean recursiveSecondLevel = true;
+        boolean isStopThenStart = true;
+        boolean directVariableInitialization = false;
+
+        verifyRegisterProblem(stopMethod, startMethod, isStopThenStart, packageName, numOfInvocations, sameVariable, recursiveSecondLevel, directVariableInitialization);
+    }
+
+    /**
+     * This test case tests the StopThenStartOnServiceBusProcessorCheck class when 'start' is not called after 'stop'
+     * on the same variable in a recursive second level method.
+     * The test case should not register a problem with the ProblemsHolder.
+     */
+    @Test
+    public void testSameVariableRecursiveStartThenStop() {
+        String stopMethod = "stop";
+        String startMethod = "start";
+        String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
         int numOfInvocations = 0;
 
         boolean sameVariable = true;
+        boolean recursiveSecondLevel = true;
+        boolean isStopThenStart = false;
+        boolean directVariableInitialization = true;
 
-        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, numOfInvocations, sameVariable);
+        verifyRegisterProblem(stopMethod, startMethod, isStopThenStart, packageName, numOfInvocations, sameVariable, recursiveSecondLevel, directVariableInitialization);
     }
 
+    /**
+     * This test case tests the StopThenStartOnServiceBusProcessorCheck class when `stop` is called before `start`
+     * on different variables in a recursive second level method.
+     * The test case should not register a problem with the ProblemsHolder.
+     */
+    @Test
+    public void testDifferentVariablesRecursiveStopThenStart() {
+        String stopMethod = "stop";
+        String startMethod = "start";
+        String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
+        int numOfInvocations = 0;
+
+        boolean sameVariable = false;
+        boolean recursiveSecondLevel = true;
+        boolean isStopThenStart = true;
+        boolean directVariableInitialization = false;
+
+        verifyRegisterProblem(stopMethod, startMethod, isStopThenStart, packageName, numOfInvocations, sameVariable, recursiveSecondLevel, directVariableInitialization);
+    }
+
+    /**
+     * This test case tests the StopThenStartOnServiceBusProcessorCheck class when 'start' is not called after 'stop'
+     * on different variables in a recursive second level method.
+     * The test case should not register a problem with the ProblemsHolder.
+     */
+    @Test
+    public void testDifferentVariablesRecursiveStartThenStop() {
+        String stopMethod = "stop";
+        String startMethod = "start";
+        String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
+        int numOfInvocations = 0;
+
+        boolean sameVariable = false;
+        boolean recursiveSecondLevel = true;
+        boolean isStopThenStart = false;
+        boolean directVariableInitialization = true;
+
+        verifyRegisterProblem(stopMethod, startMethod, isStopThenStart, packageName, numOfInvocations, sameVariable, recursiveSecondLevel, directVariableInitialization);
+    }
 
     /**
      * This helper method creates a new StopThenStartOnServiceBusProcessorVisitor object
@@ -114,59 +221,124 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
      * This helper method verifies that the ProblemsHolder has been registered with the problem
      *
      * @param stopMethod       the stop method to be called
-     * @param isStopMethod     a boolean indicating if the stop method is called
      * @param startMethod      the start method to be called
-     * @param isStartMethod    a boolean indicating if the start method is called
      * @param packageName      the package name of the variable
      * @param numOfInvocations the number of times the problem should be registered
      * @param sameVariable     a boolean indicating if the start method is called on the same variable
      */
-    private void verifyRegisterProblem(String stopMethod, boolean isStopMethod, String startMethod, boolean isStartMethod, String packageName, int numOfInvocations, boolean sameVariable) {
+    private void verifyRegisterProblem(String stopMethod, String startMethod, boolean isStopThenStart, String packageName, int numOfInvocations, boolean sameVariable, boolean recursiveSecondLevel, boolean directVariableInitialization) {
 
-        PsiMethodCallExpression stopMethodCallExpression = mock(PsiMethodCallExpression.class);
-        PsiReferenceExpression stopMethodExpression = mock(PsiReferenceExpression.class);
+        PsiNewExpression newExpression = mock(PsiNewExpression.class);
+        PsiMethod method = mock(PsiMethod.class);
+        PsiCodeBlock mainBody = mock(PsiCodeBlock.class);
+        PsiCodeBlock secondBody = mock(PsiCodeBlock.class);
 
-        PsiReferenceExpression qualifierExpression = mock(PsiReferenceExpression.class);
+        when(newExpression.getParent()).thenReturn(method);
 
-        PsiMethodCallExpression startMethodCallExpression = mock(PsiMethodCallExpression.class);
-        PsiReferenceExpression startMethodExpression = mock(PsiReferenceExpression.class);
+        if (recursiveSecondLevel) {
+            when(method.getBody()).thenReturn(mainBody);
+        } else {
+            when(method.getBody()).thenReturn(secondBody);
+        }
 
-        PsiVariable variable = mock(PsiVariable.class);
-        PsiType type = mock(PsiType.class);
-
+        // findAssociatedVariable method
+        PsiVariable findAssociatedVariable = mock(PsiVariable.class);
+        PsiAssignmentExpression assignmentExpression = mock(PsiAssignmentExpression.class);
+        PsiReferenceExpression referenceExpression = mock(PsiReferenceExpression.class);
 
         // isServiceBusProcessorClient method
-        when(variable.getType()).thenReturn(type);
+        PsiType type = mock(PsiType.class);
+
+        // visitMethodBody method
+        PsiExpressionStatement stopChild = mock(PsiExpressionStatement.class);
+        PsiExpressionStatement startChild = mock(PsiExpressionStatement.class);
+
+        PsiElement[] stopStartChildren;
+        if (isStopThenStart) {
+            stopStartChildren = new PsiElement[]{stopChild, startChild};
+        } else {
+            stopStartChildren = new PsiElement[]{startChild, stopChild};
+        }
+
+        PsiMethodCallExpression stopExpression = mock(PsiMethodCallExpression.class);
+        PsiMethodCallExpression startExpression = mock(PsiMethodCallExpression.class);
+        PsiReferenceExpression stopMethodExpression = mock(PsiReferenceExpression.class);
+        PsiReferenceExpression startMethodExpression = mock(PsiReferenceExpression.class);
+        PsiReferenceExpression stopQualifierExpression = mock(PsiReferenceExpression.class);
+        PsiReferenceExpression startQualifierExpression = mock(PsiReferenceExpression.class);
+
+        PsiVariable stopResolvedElement = mock(PsiVariable.class);
+        PsiVariable startResolvedElement = mock(PsiVariable.class);
+
+        PsiMethodCallExpression helperExpression = mock(PsiMethodCallExpression.class);
+        PsiReferenceExpression helperMethodExpression = mock(PsiReferenceExpression.class);
+        PsiReferenceExpression helperQualifierExpression = mock(PsiReferenceExpression.class);
+
+        PsiMethod helperMethod = mock(PsiMethod.class);
+        PsiFile containingFile = mock(PsiFile.class);
+        Project project = mock(Project.class);
+        ProjectRootManager projectRootManager = mock(ProjectRootManager.class);
+        ProjectFileIndex projectFileIndex = mock(ProjectFileIndex.class);
+        PsiExpressionStatement otherChild = mock(PsiExpressionStatement.class);
+        PsiElement[] otherChildren = new PsiElement[]{otherChild};
+
+        // findAssociatedVariable method
+        if (directVariableInitialization) {
+            when(newExpression.getParent()).thenReturn(findAssociatedVariable);
+        } else {
+
+            when(newExpression.getParent()).thenReturn(assignmentExpression);
+            when(assignmentExpression.getLExpression()).thenReturn(referenceExpression);
+            when(referenceExpression.resolve()).thenReturn(findAssociatedVariable);
+        }
+
+        // isServiceBusProcessorClient method
+        when(findAssociatedVariable.getType()).thenReturn(type);
         when(type.getCanonicalText()).thenReturn(packageName);
 
-        // visitMethodCallExpression method
-        when(qualifierExpression.resolve()).thenReturn(variable);
+        // visitMethodBody method & checkMethodCall method
+        when(secondBody.getChildren()).thenReturn(stopStartChildren);
 
-        if (isStopMethod) {
-            when(stopMethodCallExpression.getMethodExpression()).thenReturn(stopMethodExpression);
-            when(stopMethodExpression.getReferenceName()).thenReturn(stopMethod);
-            when(stopMethodExpression.getQualifierExpression()).thenReturn(qualifierExpression);
-            mockVisitor.visitMethodCallExpression(stopMethodCallExpression);
+        when(stopChild.getExpression()).thenReturn(stopExpression);
+        when(startChild.getExpression()).thenReturn(startExpression);
+
+        when(stopExpression.getMethodExpression()).thenReturn(stopMethodExpression);
+        when(startExpression.getMethodExpression()).thenReturn(startMethodExpression);
+        when(stopMethodExpression.getQualifierExpression()).thenReturn(stopQualifierExpression);
+        when(startMethodExpression.getQualifierExpression()).thenReturn(startQualifierExpression);
+
+        if (sameVariable) {
+            when(stopQualifierExpression.resolve()).thenReturn(findAssociatedVariable);
+            when(startQualifierExpression.resolve()).thenReturn(findAssociatedVariable);
+        } else {
+            when(stopQualifierExpression.resolve()).thenReturn(stopResolvedElement);
+            when(startQualifierExpression.resolve()).thenReturn(startResolvedElement);
         }
 
-        if (isStartMethod) {
-            when(startMethodCallExpression.getMethodExpression()).thenReturn(startMethodExpression);
-            when(startMethodExpression.getReferenceName()).thenReturn(startMethod);
+        when(stopMethodExpression.getReferenceName()).thenReturn(stopMethod);
+        when(startMethodExpression.getReferenceName()).thenReturn(startMethod);
 
-            if (!sameVariable) {
-                PsiReferenceExpression qualifierExpression3 = mock(PsiReferenceExpression.class);
-                PsiVariable variable3 = mock(PsiVariable.class);
+        when(mainBody.getChildren()).thenReturn(otherChildren);
+        when(otherChild.getExpression()).thenReturn(helperExpression);
+        when(helperExpression.getMethodExpression()).thenReturn(helperMethodExpression);
+        when(helperMethodExpression.getQualifierExpression()).thenReturn(helperQualifierExpression);
+        when(helperQualifierExpression.resolve()).thenReturn(null);
 
-                when(startMethodExpression.getQualifierExpression()).thenReturn(qualifierExpression3);
-                when(qualifierExpression3.resolve()).thenReturn(variable3);
-                when(variable3.getType()).thenReturn(type);
-            } else {
-                when(startMethodExpression.getQualifierExpression()).thenReturn(qualifierExpression);
-            }
-            mockVisitor.visitMethodCallExpression(startMethodCallExpression);
-        }
+        when(helperExpression.resolveMethod()).thenReturn(helperMethod);
+
+        // isFileInCurrentProject method
+        when(helperMethod.getContainingFile()).thenReturn(containingFile);
+        when(containingFile.getProject()).thenReturn(project);
+        when(projectRootManager.getInstance(project)).thenReturn(projectRootManager);
+        when(projectRootManager.getFileIndex()).thenReturn(projectFileIndex);
+        when(projectFileIndex.isInContent(containingFile.getVirtualFile())).thenReturn(true);
+
+        when(helperMethod.getBody()).thenReturn(secondBody);
+
+        mockVisitor.visitElement(newExpression);
+        mockVisitor.visitMethod(method);
 
         // Verify that the ProblemsHolder has been registered with the problem
-        verify(mockHolder, times(numOfInvocations)).registerProblem(eq(startMethodCallExpression), contains("Starting Processor that was stopped before is not recommended, and this feature may be deprecated in the future. Please close this processor instance and create a new one to restart processing"));
+        verify(mockHolder, times(numOfInvocations)).registerProblem(eq(startExpression), contains("Starting Processor that was stopped before is not recommended, and this feature may be deprecated in the future. Please close this processor instance and create a new one to restart processing"));
     }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheckTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheckTest.java
@@ -50,39 +50,12 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
         String startMethod = "start";
         boolean isStartMethod = true;
 
-        String closeMethod = "close";
-        boolean isCloseMethod = false;
-
         String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
         int numOfInvocations = 1;
 
         boolean sameVariable = true;
 
-        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, closeMethod, isCloseMethod, numOfInvocations, sameVariable);
-    }
-
-    /**
-     * If a stop method is called on a ServiceBusProcessorClient object, followed by a close method call on the same object
-     * Calling a start method on the same object afterward should not register a problem with the ProblemsHolder
-     */
-    @Test
-    public void testStopThenCloseThenStart() {
-
-        String stopMethod = "stop";
-        boolean isStopMethod = true;
-
-        String startMethod = "start";
-        boolean isStartMethod = true;
-
-        String closeMethod = "close";
-        boolean isCloseMethod = true;
-
-        String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
-        int numOfInvocations = 0;
-
-        boolean sameVariable = true;
-
-        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, closeMethod, isCloseMethod, numOfInvocations, sameVariable);
+        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, numOfInvocations, sameVariable);
     }
 
     /**
@@ -98,15 +71,12 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
         String startMethod = "start";
         boolean isStartMethod = true;
 
-        String closeMethod = "close";
-        boolean isCloseMethod = false;
-
         String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
         int numOfInvocations = 0;
 
         boolean sameVariable = false;
 
-        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, closeMethod, isCloseMethod, numOfInvocations, sameVariable);
+        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, numOfInvocations, sameVariable);
     }
 
     /**
@@ -122,15 +92,12 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
         String startMethod = "start";
         boolean isStartMethod = true;
 
-        String closeMethod = "close";
-        boolean isCloseMethod = false;
-
         String packageName = "com.azure.messaging.servicebus.ServiceBusReceiverAsyncClient";
         int numOfInvocations = 0;
 
         boolean sameVariable = true;
 
-        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, closeMethod, isCloseMethod, numOfInvocations, sameVariable);
+        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, numOfInvocations, sameVariable);
     }
 
 
@@ -151,12 +118,10 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
      * @param startMethod      the start method to be called
      * @param isStartMethod    a boolean indicating if the start method is called
      * @param packageName      the package name of the variable
-     * @param closeMethod      the close method to be called
-     * @param isCloseMethod    a boolean indicating if the close method is called
      * @param numOfInvocations the number of times the problem should be registered
      * @param sameVariable     a boolean indicating if the start method is called on the same variable
      */
-    private void verifyRegisterProblem(String stopMethod, boolean isStopMethod, String startMethod, boolean isStartMethod, String packageName, String closeMethod, boolean isCloseMethod, int numOfInvocations, boolean sameVariable) {
+    private void verifyRegisterProblem(String stopMethod, boolean isStopMethod, String startMethod, boolean isStartMethod, String packageName, int numOfInvocations, boolean sameVariable) {
 
         PsiMethodCallExpression stopMethodCallExpression = mock(PsiMethodCallExpression.class);
         PsiReferenceExpression stopMethodExpression = mock(PsiReferenceExpression.class);
@@ -165,9 +130,6 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
 
         PsiMethodCallExpression startMethodCallExpression = mock(PsiMethodCallExpression.class);
         PsiReferenceExpression startMethodExpression = mock(PsiReferenceExpression.class);
-
-        PsiMethodCallExpression closeMethodCallExpression = mock(PsiMethodCallExpression.class);
-        PsiReferenceExpression closeMethodExpression = mock(PsiReferenceExpression.class);
 
         PsiVariable variable = mock(PsiVariable.class);
         PsiType type = mock(PsiType.class);
@@ -185,13 +147,6 @@ public class StopThenStartOnServiceBusProcessorCheckTest {
             when(stopMethodExpression.getReferenceName()).thenReturn(stopMethod);
             when(stopMethodExpression.getQualifierExpression()).thenReturn(qualifierExpression);
             mockVisitor.visitMethodCallExpression(stopMethodCallExpression);
-        }
-
-        if (isCloseMethod) {
-            when(closeMethodCallExpression.getMethodExpression()).thenReturn(closeMethodExpression);
-            when(closeMethodExpression.getReferenceName()).thenReturn(closeMethod);
-            when(closeMethodExpression.getQualifierExpression()).thenReturn(qualifierExpression);
-            mockVisitor.visitMethodCallExpression(closeMethodCallExpression);
         }
 
         if (isStartMethod) {

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheckTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/StopThenStartOnServiceBusProcessorCheckTest.java
@@ -1,0 +1,217 @@
+package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
+
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.PsiReferenceExpression;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.PsiVariable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.StopThenStartOnServiceBusProcessorCheck.StopThenStartOnServiceBusProcessorVisitor;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class StopThenStartOnServiceBusProcessorCheckTest {
+
+
+    // Create a mock ProblemsHolder to be used in the test
+    @Mock
+    private ProblemsHolder mockHolder;
+
+    // Create a mock visitor for visiting the PsiMethodCallExpression
+    @Mock
+    private StopThenStartOnServiceBusProcessorVisitor mockVisitor;
+
+
+    @BeforeEach
+    public void setUp() {
+        // Set up the test
+        mockHolder = mock(ProblemsHolder.class);
+        mockVisitor = createVisitor();
+    }
+
+    /**
+     * If a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on the same object
+     * the test should register a problem with the ProblemsHolder
+     */
+    @Test
+    public void testStopThenStart() {
+
+        String stopMethod = "stop";
+        boolean isStopMethod = true;
+
+        String startMethod = "start";
+        boolean isStartMethod = true;
+
+        String closeMethod = "close";
+        boolean isCloseMethod = false;
+
+        String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
+        int numOfInvocations = 1;
+
+        boolean sameVariable = true;
+
+        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, closeMethod, isCloseMethod, numOfInvocations, sameVariable);
+    }
+
+    /**
+     * If a stop method is called on a ServiceBusProcessorClient object, followed by a close method call on the same object
+     * Calling a start method on the same object afterward should not register a problem with the ProblemsHolder
+     */
+    @Test
+    public void testStopThenCloseThenStart() {
+
+        String stopMethod = "stop";
+        boolean isStopMethod = true;
+
+        String startMethod = "start";
+        boolean isStartMethod = true;
+
+        String closeMethod = "close";
+        boolean isCloseMethod = true;
+
+        String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
+        int numOfInvocations = 0;
+
+        boolean sameVariable = true;
+
+        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, closeMethod, isCloseMethod, numOfInvocations, sameVariable);
+    }
+
+    /**
+     * If a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on a different object of the same type
+     * the test should not register a problem with the ProblemsHolder
+     */
+    @Test
+    public void testStopStartDifferentVariables() {
+
+        String stopMethod = "stop";
+        boolean isStopMethod = true;
+
+        String startMethod = "start";
+        boolean isStartMethod = true;
+
+        String closeMethod = "close";
+        boolean isCloseMethod = false;
+
+        String packageName = "com.azure.messaging.servicebus.ServiceBusProcessorClient";
+        int numOfInvocations = 0;
+
+        boolean sameVariable = false;
+
+        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, closeMethod, isCloseMethod, numOfInvocations, sameVariable);
+    }
+
+    /**
+     * If a stop method is called on a different client service, even if the start method is called on the same client service
+     * the test should not register a problem with the ProblemsHolder
+     */
+    @Test
+    public void testStopThenStartDifferentService() {
+
+        String stopMethod = "stop";
+        boolean isStopMethod = true;
+
+        String startMethod = "start";
+        boolean isStartMethod = true;
+
+        String closeMethod = "close";
+        boolean isCloseMethod = false;
+
+        String packageName = "com.azure.messaging.servicebus.ServiceBusReceiverAsyncClient";
+        int numOfInvocations = 0;
+
+        boolean sameVariable = true;
+
+        verifyRegisterProblem(stopMethod, isStopMethod, startMethod, isStartMethod, packageName, closeMethod, isCloseMethod, numOfInvocations, sameVariable);
+    }
+
+
+    /**
+     * This helper method creates a new StopThenStartOnServiceBusProcessorVisitor object
+     *
+     * @return a new StopThenStartOnServiceBusProcessorVisitor object
+     */
+    private StopThenStartOnServiceBusProcessorVisitor createVisitor() {
+        return new StopThenStartOnServiceBusProcessorVisitor(mockHolder);
+    }
+
+    /**
+     * This helper method verifies that the ProblemsHolder has been registered with the problem
+     *
+     * @param stopMethod       the stop method to be called
+     * @param isStopMethod     a boolean indicating if the stop method is called
+     * @param startMethod      the start method to be called
+     * @param isStartMethod    a boolean indicating if the start method is called
+     * @param packageName      the package name of the variable
+     * @param closeMethod      the close method to be called
+     * @param isCloseMethod    a boolean indicating if the close method is called
+     * @param numOfInvocations the number of times the problem should be registered
+     * @param sameVariable     a boolean indicating if the start method is called on the same variable
+     */
+    private void verifyRegisterProblem(String stopMethod, boolean isStopMethod, String startMethod, boolean isStartMethod, String packageName, String closeMethod, boolean isCloseMethod, int numOfInvocations, boolean sameVariable) {
+
+        PsiMethodCallExpression stopMethodCallExpression = mock(PsiMethodCallExpression.class);
+        PsiReferenceExpression stopMethodExpression = mock(PsiReferenceExpression.class);
+
+        PsiReferenceExpression qualifierExpression = mock(PsiReferenceExpression.class);
+
+        PsiMethodCallExpression startMethodCallExpression = mock(PsiMethodCallExpression.class);
+        PsiReferenceExpression startMethodExpression = mock(PsiReferenceExpression.class);
+
+        PsiMethodCallExpression closeMethodCallExpression = mock(PsiMethodCallExpression.class);
+        PsiReferenceExpression closeMethodExpression = mock(PsiReferenceExpression.class);
+
+        PsiVariable variable = mock(PsiVariable.class);
+        PsiType type = mock(PsiType.class);
+
+
+        // isServiceBusProcessorClient method
+        when(variable.getType()).thenReturn(type);
+        when(type.getCanonicalText()).thenReturn(packageName);
+
+        // visitMethodCallExpression method
+        when(qualifierExpression.resolve()).thenReturn(variable);
+
+        if (isStopMethod) {
+            when(stopMethodCallExpression.getMethodExpression()).thenReturn(stopMethodExpression);
+            when(stopMethodExpression.getReferenceName()).thenReturn(stopMethod);
+            when(stopMethodExpression.getQualifierExpression()).thenReturn(qualifierExpression);
+            mockVisitor.visitMethodCallExpression(stopMethodCallExpression);
+        }
+
+        if (isCloseMethod) {
+            when(closeMethodCallExpression.getMethodExpression()).thenReturn(closeMethodExpression);
+            when(closeMethodExpression.getReferenceName()).thenReturn(closeMethod);
+            when(closeMethodExpression.getQualifierExpression()).thenReturn(qualifierExpression);
+            mockVisitor.visitMethodCallExpression(closeMethodCallExpression);
+        }
+
+        if (isStartMethod) {
+            when(startMethodCallExpression.getMethodExpression()).thenReturn(startMethodExpression);
+            when(startMethodExpression.getReferenceName()).thenReturn(startMethod);
+
+            if (!sameVariable) {
+                PsiReferenceExpression qualifierExpression3 = mock(PsiReferenceExpression.class);
+                PsiVariable variable3 = mock(PsiVariable.class);
+
+                when(startMethodExpression.getQualifierExpression()).thenReturn(qualifierExpression3);
+                when(qualifierExpression3.resolve()).thenReturn(variable3);
+                when(variable3.getType()).thenReturn(type);
+            } else {
+                when(startMethodExpression.getQualifierExpression()).thenReturn(qualifierExpression);
+            }
+            mockVisitor.visitMethodCallExpression(startMethodCallExpression);
+        }
+
+        // Verify that the ProblemsHolder has been registered with the problem
+        verify(mockHolder, times(numOfInvocations)).registerProblem(eq(startMethodCallExpression), contains("Starting Processor that was stopped before is not recommended, and this feature may be deprecated in the future. Please close this processor instance and create a new one to restart processing"));
+    }
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This class is a LocalInspectionTool that checks if a stop method is called on a ServiceBusProcessorClient object, followed by a start method call on the same object.
If this is the case, a problem is registered with the ProblemsHolder.

A problem is not registered when .close() is used before a .start() on the same client that's a class instance object.

Has this been tested?
---------------------------
- [x] Tested

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
![image](https://github.com/user-attachments/assets/90b89c66-0295-409e-acfb-70de2089ab2c)

![image](https://github.com/user-attachments/assets/6d647e5f-33db-4ff0-bd9a-58d4209a0dff)


![image](https://github.com/user-attachments/assets/4b4ebb88-cfcc-4a5d-844e-89052798dfb2)

![image](https://github.com/user-attachments/assets/c8f4a1ba-2879-4e4a-8255-a30d350112f5)