### PR TITLE
checking for use of implementation types

### DIFF
--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
@@ -260,3 +260,13 @@ integration, telemetry connectivity, and Azure Toolkit integration.
   Please refer to
   the [KeyCredential Class documentation](https://learn.microsoft.com/java/api/com.azure.core.credential.keycredential?view=azure-java-stable)
   for more information.
+
+14. ## Using Concrete Classes Instead of Interfaces
+
+**Anti-pattern**: Using concrete classes directly instead of interfaces.
+- **Issue**: Relying on concrete classes ties your code to a specific implementation, making it harder to change the
+  underlying implementation without modifying the code that depends on it. Using interfaces or abstract classes allows
+  you to switch implementations easily.
+- **Severity: WARNING**
+- **Recommendation**: Define an interface for the class to implement and use the interface type for declarations and
+  method signatures to improve flexibility and maintainability.

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
@@ -261,12 +261,11 @@ integration, telemetry connectivity, and Azure Toolkit integration.
   the [KeyCredential Class documentation](https://learn.microsoft.com/java/api/com.azure.core.credential.keycredential?view=azure-java-stable)
   for more information.
 
-14. ## Using Concrete Classes Instead of Interfaces
+14. ## Using Implementation Types instead of Publicly Available Azure Classes
 
-**Anti-pattern**: Using concrete classes directly instead of interfaces.
-- **Issue**: Relying on concrete classes ties your code to a specific implementation, making it harder to change the
-  underlying implementation without modifying the code that depends on it. Using interfaces or abstract classes allows
-  you to switch implementations easily.
+**Anti-pattern**: Using implementation types instead of publicly available Azure classes.
+- **Issue**: Implementation types are internal classes that are not intended for public use. They may change or be
+  removed
+  in future versions, leading to compatibility issues.
 - **Severity: WARNING**
-- **Recommendation**: Define an interface for the class to implement and use the interface type for declarations and
-  method signatures to improve flexibility and maintainability.
+- **Recommendation**: Use the publicly available Azure classes instead.

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/README.md
@@ -267,5 +267,5 @@ integration, telemetry connectivity, and Azure Toolkit integration.
 - **Issue**: Implementation types are internal classes that are not intended for public use. They may change or be
   removed
   in future versions, leading to compatibility issues.
-- **Severity: WARNING**
+- **Severity: ERROR**
 - **Recommendation**: Use the publicly available Azure classes instead.

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ImplementationTypeCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ImplementationTypeCheck.java
@@ -1,0 +1,176 @@
+package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
+
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiClassType;
+import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiType;
+import com.intellij.psi.PsiVariable;
+import org.jetbrains.annotations.NotNull;
+
+
+/**
+ * This class checks for the usage of concrete classes to promote better design practices.
+ *
+ * <p>Two main cases are flagged:</p>
+ *
+ * <ul>
+ *   <li><b>Case 1:</b> The class does not implement any interfaces or extend any classes (except java.lang.Object).
+ *   <br>This is flagged because it is a standalone concrete class, which limits flexibility and testability.</li>
+ *
+ *   <li><b>Case 2:</b> The class implements interfaces or extends a superclass, but is directly used as a concrete type.
+ *   <br>This is flagged because, even though the class is part of a hierarchy, using the concrete type directly bypasses the benefits of programming to an interface, such as flexibility and ease of testing.</li>
+ * </ul>
+ *
+ * <p>Classes that only implement or extend Java utility classes/interfaces are not flagged, as they are considered part of the standard Java hierarchy.</p>
+ */
+
+public class ImplementationTypeCheck extends LocalInspectionTool {
+
+    /**
+     * Build the visitor for the inspection. This visitor will be used to traverse the PSI tree.
+     *
+     * @param holder The holder for the problems found
+     * @return The visitor for the inspection
+     */
+    @NotNull
+    @Override
+    public JavaElementVisitor buildVisitor(@NotNull ProblemsHolder holder, boolean isOnTheFly) {
+        return new ImplementationTypeVisitor(holder);
+    }
+
+    /**
+     * This class extends the JavaElementVisitor to visit the elements in the code.
+     * It checks if the variable type is a concrete class and if the class has implemented interfaces.
+     * If both conditions are met, a problem is registered with the suggestion message to use interfaces instead of concrete classes.
+     */
+    static class ImplementationTypeVisitor extends JavaElementVisitor {
+
+        private final ProblemsHolder holder;
+
+        /**
+         * Constructor for the visitor
+         *
+         * @param holder - the ProblemsHolder object to register the problem
+         */
+        ImplementationTypeVisitor(ProblemsHolder holder) {
+            this.holder = holder;
+        }
+
+        // Define constants for string literals
+        private static final RuleConfig RULE_CONFIG;
+        private static final boolean SKIP_WHOLE_RULE;
+
+        static {
+            final String ruleName = "ImplementationTypeCheck";
+            RuleConfigLoader centralRuleConfigLoader = RuleConfigLoader.getInstance();
+
+            // Get the RuleConfig object for the rule
+            RULE_CONFIG = centralRuleConfigLoader.getRuleConfig(ruleName);
+            SKIP_WHOLE_RULE = RULE_CONFIG.skipRuleCheck() || RULE_CONFIG.getAntiPatternMessageMap().isEmpty();
+        }
+
+        /**
+         * This method visits the variables in the code.
+         * It checks if the variable type is a concrete class and if the class has implemented interfaces.
+         * If both conditions are met, a problem is registered with the suggestion message to use interfaces instead of concrete classes.
+         */
+        @Override
+        public void visitVariable(@NotNull PsiVariable variable) {
+            super.visitVariable(variable);
+
+            if (SKIP_WHOLE_RULE) {
+                return;
+            }
+
+            // Get the type of the variable - This is the type of the variable declaration
+            // eg. List<String> myList = new ArrayList<>(); -> type = List<String>
+            PsiType type = variable.getType();
+
+            if (isConcreteClass(type)) {
+
+                // Handle the concrete implementation type
+                PsiClass psiClass = ((PsiClassType) type).resolve();
+
+                if (psiClass != null && hasImplementedInterfaces(type)) {
+                    holder.registerProblem(variable, RULE_CONFIG.getAntiPatternMessageMap().get("antiPatternMessage"));
+                }
+            }
+        }
+
+        /**
+         * This method checks if the type is a concrete class.
+         * This is done by checking if the type is a class and if the class is not an interface or abstract class.
+         *
+         * @param type The type to check
+         * @return True if the type is a concrete class, false otherwise
+         */
+        private boolean isConcreteClass(PsiType type) {
+
+            if (!(type instanceof PsiClassType)) {
+                return false;
+            }
+            PsiClass psiClass = ((PsiClassType) type).resolve();
+
+            if (psiClass == null) {
+                return false;
+            }
+
+            // isInterface() returns true if the class is an interface
+            // hasModifierProperty returns true if the class is abstract
+            return !psiClass.isInterface() && !psiClass.hasModifierProperty(PsiModifier.ABSTRACT);
+        }
+
+        /**
+         * This method checks if the class has implemented interfaces.
+         * This is done by checking if the class implements interfaces or extends a class that is not
+         * from the java.lang package.
+         *
+         * @param type The type to check
+         * @return True if the class has implemented interfaces, false otherwise
+         */
+        private boolean hasImplementedInterfaces(PsiType type) {
+            if (type instanceof PsiClassType) {
+                PsiClass psiClass = ((PsiClassType) type).resolve();
+
+                if (psiClass != null) {
+                    // Exclude classes from java.lang package
+                    if (psiClass.getQualifiedName() != null && (psiClass.getQualifiedName().startsWith("java.") || psiClass.getQualifiedName().startsWith("javax."))) {
+                        return false;
+                    }
+
+                    PsiClass[] interfaces = psiClass.getInterfaces();
+                    PsiClass superClass = psiClass.getSuperClass();
+
+                    // Case 1: Class has no implemented interfaces and does not extend any class
+                    if (interfaces.length == 0 && superClass != null && superClass.getQualifiedName().equals("java.lang.Object")) {
+                        return true;
+                    }
+
+                    // Case 2: Class has implemented interfaces or extends a class that is not from java.lang package
+                    if (interfaces.length > 0 || (superClass != null && !superClass.getQualifiedName().startsWith("java."))) {
+
+                        for (PsiClass iface : interfaces) {
+
+                            // If none of the interfaces are from java.lang or javax packages return true
+                            String ifaceName = iface.getQualifiedName();
+                            if (ifaceName != null && !ifaceName.startsWith("java.") && !ifaceName.startsWith("javax.")) {
+                                return true;
+                            }
+                        }
+
+                        // If the super class is not from java.lang or javax packages return true
+                        if (superClass != null) {
+                            String superClassName = superClass.getQualifiedName();
+                            return superClassName != null && !superClassName.equals("java.lang.Object") && !superClassName.startsWith("java.") && !superClassName.startsWith("javax.");
+                        }
+                    }
+
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ImplementationTypeCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ImplementationTypeCheck.java
@@ -19,8 +19,8 @@ public class ImplementationTypeCheck extends LocalInspectionTool {
     /**
      * Build the visitor for the inspection. This visitor will be used to traverse the PSI tree.
      *
-     * @param holder The holder for the problems found
-     *@param isOnTheFly Whether the inspection is being run on the fly - This is not used in this implementation, but is required by the interface
+     * @param holder     The holder for the problems found
+     * @param isOnTheFly Whether the inspection is being run on the fly - This is not used in this implementation, but is required by the interface
      * @return The visitor for the inspection
      */
     @NotNull
@@ -99,8 +99,15 @@ public class ImplementationTypeCheck extends LocalInspectionTool {
             if (psiClass == null) {
                 return false;
             }
-            // Check if the class is in the Azure package and if it is an implementation type
-            return psiClass.getQualifiedName().startsWith(RuleConfig.AZURE_PACKAGE_NAME) && psiClass.getQualifiedName().contains(RULE_CONFIG.getListedItemsToCheck().get(0));
+
+            for (String listedItem : RULE_CONFIG.getListedItemsToCheck()) {
+                if (psiClass.getQualifiedName() != null && psiClass.getQualifiedName().contains(listedItem)) {
+
+                    // Check if the class is in the Azure package and if it is an implementation type
+                    return psiClass.getQualifiedName().startsWith(RuleConfig.AZURE_PACKAGE_NAME) && psiClass.getQualifiedName().contains(listedItem);
+                }
+            }
+            return false;
         }
 
         /**

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ImplementationTypeCheck.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ImplementationTypeCheck.java
@@ -80,7 +80,7 @@ public class ImplementationTypeCheck extends LocalInspectionTool {
                 holder.registerProblem(variable.getNameIdentifier(), RULE_CONFIG.getAntiPatternMessageMap().get("antiPatternMessage"));
 
                 // Check if the type extends or implements an implementation type
-            } else if (ExtendsOrImplementsImplementationType(type) && variable.getNameIdentifier() != null) {
+            } else if (extendsOrImplementsImplementationType(type) && variable.getNameIdentifier() != null) {
                 holder.registerProblem(variable.getNameIdentifier(), RULE_CONFIG.getAntiPatternMessageMap().get("antiPatternMessage"));
             }
         }
@@ -107,7 +107,7 @@ public class ImplementationTypeCheck extends LocalInspectionTool {
          * This method checks if the type is a class that extends or implements an implementation type.
          * It returns true if the type extends or implements an implementation type and false otherwise.
          */
-        private boolean ExtendsOrImplementsImplementationType(PsiType type) {
+        private boolean extendsOrImplementsImplementationType(PsiType type) {
             if (type instanceof PsiClassType) {
                 PsiClass psiClass = ((PsiClassType) type).resolve();
 

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/RuleConfigLoader.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/RuleConfigLoader.java
@@ -160,7 +160,7 @@ class RuleConfigLoader {
                 case "regexPatterns":
                     listedItemsToCheck = getValuesFromJsonReader(reader);
                     break;
-                case "typesToCheck":
+                case "subPackageName":
                     listedItemsToCheck = getListFromJsonArray(reader);
                     break;
                 default:

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/RuleConfigLoader.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/RuleConfigLoader.java
@@ -160,6 +160,9 @@ class RuleConfigLoader {
                 case "regexPatterns":
                     listedItemsToCheck = getValuesFromJsonReader(reader);
                     break;
+                case "typesToCheck":
+                    listedItemsToCheck = getListFromJsonArray(reader);
+                    break;
                 default:
                     if (fieldName.endsWith("Check")) {
                         // Move to the next token to process the nested object

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
@@ -221,5 +221,19 @@
                 com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.EndpointOnNonAzureOpenAIAuthCheck
             </class>
         </localInspection>
+
+        <localInspection
+                language="JAVA"
+                shortName="ImplementationTypeCheck"
+                displayName="Implementation Type Check"
+                groupName="Azure SDK"
+                enabledByDefault="true"
+                level="WARNING"
+                implementationClass="com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.ImplementationTypeCheck">
+
+            <class>
+                com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.ImplementationTypeCheck
+            </class>
+        </localInspection>
     </extensions>
 </idea-plugin>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/azure-intellij-plugin-azure-sdk.xml
@@ -228,7 +228,7 @@
                 displayName="Implementation Type Check"
                 groupName="Azure SDK"
                 enabledByDefault="true"
-                level="WARNING"
+                level="ERROR"
                 implementationClass="com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.ImplementationTypeCheck">
 
             <class>

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
@@ -119,7 +119,7 @@
     "antiPatternMessage": "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients"
   },
   "ImplementationTypeCheck": {
-    "typesToCheck": "implementation",
+    "subPackageName": "implementation",
     "antiPatternMessage": "Detected usage of an implementation type. Implementation types are not intended for public use. Use the publicly available Azure classes instead."
   }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
@@ -119,6 +119,7 @@
     "antiPatternMessage": "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients"
   },
   "ImplementationTypeCheck": {
-    "antiPatternMessage": "Detected usage of a concrete implementation type. Consider using an interface or an abstract class to promote flexibility and testability."
+    "typesToCheck": "implementation",
+    "antiPatternMessage": "Detected usage of an implementation type. Implementation types are not intended for public use. Use the publicly available Azure classes instead."
   }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/main/resources/META-INF/ruleConfigs.json
@@ -117,5 +117,8 @@
     ],
     "servicesToCheck": "KeyCredential",
     "antiPatternMessage": "Endpoint should not be used with KeyCredential for non-Azure OpenAI clients"
+  },
+  "ImplementationTypeCheck": {
+    "antiPatternMessage": "Detected usage of a concrete implementation type. Consider using an interface or an abstract class to promote flexibility and testability."
   }
 }

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ImplementationTypeCheckTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ImplementationTypeCheckTest.java
@@ -1,0 +1,243 @@
+package com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool;
+
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiClassType;
+import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiVariable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.microsoft.azure.toolkit.intellij.azure.sdk.buildtool.ImplementationTypeCheck.ImplementationTypeVisitor;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class tests the ImplementationTypeVisitor class.
+ */
+public class ImplementationTypeCheckTest {
+
+    // Declare as instance variables
+    @Mock
+    private ProblemsHolder mockHolder;
+
+    @Mock
+    private JavaElementVisitor mockVisitor;
+
+    @Mock
+    private PsiVariable mockVariable;
+
+    @BeforeEach
+    public void setup() {
+        mockHolder = mock(ProblemsHolder.class);
+        mockVisitor = createVisitor();
+        mockVariable = mock(PsiVariable.class);
+    }
+
+    /**
+     * Test cases for the ImplementationTypeVisitor class.
+     * This case is for a standalone concrete class that does not implement any interfaces or extend any classes (except java.lang.Object).
+     * This is flagged because it is a standalone concrete class.
+     */
+    @Test
+    public void testStandaloneConcreteClass() {
+
+        Boolean isInterfaceBoolean = false;  // It's not an interface
+        Boolean isAbstractBoolean = false;   // It's not abstract
+        String classQualifiedName = "com.example.StandaloneClass";  // Arbitrary class name
+
+        // No interfaces implemented
+        PsiClass[] interfaces = new PsiClass[]{};
+        String interfaceQualifiedName = null;
+
+        // Extends Object (implicitly)
+        PsiClass superClass = mock(PsiClass.class);
+        String superClassQualifiedName = "java.lang.Object";  // Extends java.lang.Object
+
+        int numOfInvocations = 1;
+
+        verifyRegisterProblem(isInterfaceBoolean, isAbstractBoolean, classQualifiedName, interfaces, superClass, superClassQualifiedName, interfaceQualifiedName, numOfInvocations);
+    }
+
+    /**
+     * Test case for an interface class that a concrete class implements.
+     * This is not flagged because it is correctly used in the variable declaration.
+     */
+    @Test
+    public void testNotConcreteClass() {
+
+        Boolean isInterfaceBoolean = true;  // It's not an interface
+        Boolean isAbstractBoolean = false;   // It's not abstract
+        String classQualifiedName = "com.example.StandaloneClass";  // Arbitrary class name
+
+        // No interfaces implemented
+        PsiClass[] interfaces = new PsiClass[]{};
+        String interfaceQualifiedName = null;
+
+        // Extends Object (implicitly)
+        PsiClass superClass = mock(PsiClass.class);
+        String superClassQualifiedName = "java.lang.Object";  // Extends java.lang.Object
+
+        int numOfInvocations = 0;
+
+        verifyRegisterProblem(isInterfaceBoolean, isAbstractBoolean, classQualifiedName, interfaces, superClass, superClassQualifiedName, interfaceQualifiedName, numOfInvocations);
+    }
+
+
+    /**
+     * Test case for a concrete class that implements a custom interface.
+     * This is flagged because, even though the class is part of a hierarchy, the concrete type is used directly.
+     */
+    @Test
+    public void testConcreteClassImplementingCustomInterfaceWithVariable() {
+
+        Boolean isInterfaceBoolean = false;  // It's not an interface
+        Boolean isAbstractBoolean = false;   // It's not abstract
+        String classQualifiedName = "com.example.CustomClass";  // Arbitrary class name
+
+        // Implements a custom interface
+        PsiClass interfaceClass = mock(PsiClass.class);
+        String interfaceQualifiedName = "com.example.CustomInterface";
+        PsiClass[] interfaces = new PsiClass[]{interfaceClass};
+
+        // Does not extend any class (implicitly extends Object)
+        PsiClass superClass = mock(PsiClass.class);
+        String superClassQualifiedName = "java.lang.Object";  // Extends java.lang.Object
+
+        int numOfInvocations = 1;
+
+        verifyRegisterProblem(isInterfaceBoolean, isAbstractBoolean, classQualifiedName, interfaces, superClass, superClassQualifiedName, interfaceQualifiedName, numOfInvocations);
+    }
+
+    /**
+     * Test case for a concrete class that implements a Java utility interface.
+     * This is not flagged because it is considered part of the standard Java hierarchy.
+     */
+    @Test
+    public void testConcreteClassImplementingJavaUtilityInterface() {
+
+        Boolean isInterfaceBoolean = false;  // It's not an interface
+        Boolean isAbstractBoolean = false;   // It's not abstract
+        String classQualifiedName = "com.example.SerializableClass";  // Arbitrary class name
+
+        // Implements a Java utility interface
+        PsiClass interfaceClass = mock(PsiClass.class);
+        String interfaceQualifiedName = "java.io.Serializable";
+        PsiClass[] interfaces = new PsiClass[]{interfaceClass};
+
+        // Does not extend any class (implicitly extends Object)
+        PsiClass superClass = mock(PsiClass.class);
+        String superClassQualifiedName = "java.lang.Object";  // Extends java.lang.Object
+
+        int numOfInvocations = 0;
+
+        verifyRegisterProblem(isInterfaceBoolean, isAbstractBoolean, classQualifiedName, interfaces, superClass, superClassQualifiedName, interfaceQualifiedName, numOfInvocations);
+    }
+
+    /**
+     * Test case for a concrete class that extends a Java utility class.
+     * This is not flagged because it is considered part of the standard Java hierarchy.
+     */
+    @Test
+    public void testConcreteClassExtendingJavaUtil() {
+
+        Boolean isInterfaceBoolean = false;  // It's not an interface
+        Boolean isAbstractBoolean = false;   // It's not abstract
+        String classQualifiedName = "com.example.ArrayListSubclass";  // Arbitrary class name
+
+        // No interfaces implemented
+        PsiClass[] interfaces = new PsiClass[]{};
+        String interfaceQualifiedName = null;
+
+        // Extends a Java utility class
+        PsiClass superClass = mock(PsiClass.class);
+        String superClassQualifiedName = "java.util.ArrayList";  // Extends java.util.ArrayList
+
+        int numOfInvocations = 0;
+
+        verifyRegisterProblem(isInterfaceBoolean, isAbstractBoolean, classQualifiedName, interfaces, superClass, superClassQualifiedName, interfaceQualifiedName, numOfInvocations);
+    }
+
+    /**
+     * Test case for a concrete class that implements a custom interface and extends a Java utility class.
+     * This is flagged because it is a concrete class that is part of a hierarchy.
+     */
+    @Test
+    public void testConcreteClassImplementingCustomInterfaceAndExtendingJavaUtilityClassFlagged() {
+
+        Boolean isInterfaceBoolean = false;  // It's not an interface
+        Boolean isAbstractBoolean = false;   // It's not abstract
+        String classQualifiedName = "com.example.CustomExtendedClass";  // Arbitrary class name
+
+        // Implements a custom interface
+        PsiClass interfaceClass = mock(PsiClass.class);
+        String interfaceQualifiedName = "com.example.CustomInterface";
+        PsiClass[] interfaces = new PsiClass[]{interfaceClass};
+
+        // Extends a Java utility class
+        PsiClass superClass = mock(PsiClass.class);
+        String superClassQualifiedName = "java.util.ArrayList";  // Extends java.util.ArrayList
+        when(superClass.getQualifiedName()).thenReturn("java.util.ArrayList");
+
+        int numOfInvocations = 1;
+
+        verifyRegisterProblem(isInterfaceBoolean, isAbstractBoolean, classQualifiedName, interfaces, superClass, superClassQualifiedName, interfaceQualifiedName, numOfInvocations);
+    }
+
+    /**
+     * Helper method to create visitor.
+     *
+     * @return ImplementationTypeVisitor
+     */
+    JavaElementVisitor createVisitor() {
+        return new ImplementationTypeVisitor(mockHolder);
+    }
+
+    /**
+     * Helper method to verify registerProblem method.
+     *
+     * @param isInterfaceBoolean      True if the class is an interface, false otherwise
+     * @param isAbstractBoolean       True if the class is abstract, false otherwise
+     * @param classQualifiedName      Qualified name of the class
+     * @param interfaces              Array of interfaces implemented by the class
+     * @param superClass              Super class of the class - This is the class that the class extends
+     * @param superClassQualifiedName Qualified name of the super class
+     * @param interfaceQualifiedName  Qualified name of the interface - This is the interface that the class implements
+     * @param numOfInvocations        Number of times registerProblem method is called
+     */
+    private void verifyRegisterProblem(Boolean isInterfaceBoolean, Boolean isAbstractBoolean, String classQualifiedName, PsiClass[] interfaces, PsiClass superClass, String superClassQualifiedName, String interfaceQualifiedName, int numOfInvocations) {
+
+        PsiClassType type = mock(PsiClassType.class);
+        PsiClass psiClass = mock(PsiClass.class);
+
+        when(mockVariable.getType()).thenReturn(type);
+
+        // isConcreteClass method
+        when(type.resolve()).thenReturn(psiClass);
+        when(psiClass.isInterface()).thenReturn(isInterfaceBoolean);
+        when(psiClass.hasModifierProperty(PsiModifier.ABSTRACT)).thenReturn(isAbstractBoolean);
+
+        // hasImplementedInterfaces
+        when(psiClass.getQualifiedName()).thenReturn(classQualifiedName);
+
+        when(psiClass.getInterfaces()).thenReturn(interfaces);
+        when(psiClass.getSuperClass()).thenReturn(superClass);
+
+        when(superClass.getQualifiedName()).thenReturn(superClassQualifiedName);
+
+        if (interfaces.length > 0) {
+            when(interfaces[0].getQualifiedName()).thenReturn(interfaceQualifiedName);
+        }
+
+        mockVisitor.visitVariable(mockVariable);
+
+        verify(mockHolder, times(numOfInvocations)).registerProblem(eq(mockVariable), Mockito.contains("Detected usage of a concrete implementation type. Consider using an interface or an abstract class to promote flexibility and testability."));
+    }
+}

--- a/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ImplementationTypeCheckTest.java
+++ b/PluginsAndFeatures/azure-toolkit-for-intellij/azure-intellij-plugin-azure-sdk/src/test/java/com/microsoft/azure/toolkit/intellij/azure/sdk/buildtool/ImplementationTypeCheckTest.java
@@ -115,7 +115,7 @@ public class ImplementationTypeCheckTest {
     public void testUseOfImplementationTypeAbstractClass() {
         String classQualifiedName = "com.azure.data.appconfiguration.models";
 
-        // Implements an implementation type interface
+        // Does not implement any interface
         String interfaceQualifiedName = null;
         PsiClass[] interfaces = new PsiClass[]{};
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This class is an inspection tool that checks if a variable type is an Azure implementation type.
 If the variable type is an Azure implementation type, or if the variable type extends or implements an Azure implementation type, the inspection tool will flag it as a problem.
 
Has this been tested?
---------------------------
- [x] Tested

Any relevant logs, screenshots, error output, etc.?
-------------------------------------
![image](https://github.com/user-attachments/assets/e1a12e7f-4e32-4bc8-afc6-489cd21046d0)